### PR TITLE
feat: implement AnimaLearn demo app — BLoC + MaterialRouter + Supabase Edge Functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/medmancifra/2026-edutech/issues/3
+Your prepared branch: issue-3-d9239f5d950f
+Your prepared working directory: /tmp/gh-issue-solver-1772725991363
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/medmancifra/2026-edutech/issues/3
-Your prepared branch: issue-3-d9239f5d950f
-Your prepared working directory: /tmp/gh-issue-solver-1772725991363
-
-Proceed.

--- a/idea/architecture/system-architecture.md
+++ b/idea/architecture/system-architecture.md
@@ -1,306 +1,187 @@
-# System Architecture: AnimaLearn
+# AnimaLearn — System Architecture
+
+> **Updated per issue #3**: Navigation replaced from GoRouter → MaterialRouter,
+> state management replaced from Riverpod → BLoC (`flutter_bloc`).
+
+---
 
 ## High-Level Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                        CLIENT LAYER                                  │
-│                                                                       │
-│  ┌───────────────┐  ┌───────────────┐  ┌───────────────────────┐   │
-│  │  Flutter iOS  │  │ Flutter       │  │  Flutter Web          │   │
-│  │  & Android    │  │ Desktop       │  │  (PWA / SaaS)         │   │
-│  └───────┬───────┘  └───────┬───────┘  └──────────┬────────────┘   │
-│          └──────────────────┼──────────────────────┘                │
-│                             │ Supabase Client SDK / REST API        │
-└─────────────────────────────┼───────────────────────────────────────┘
-                              │
-┌─────────────────────────────┼───────────────────────────────────────┐
-│                        BACKEND LAYER                                 │
-│                             │                                        │
-│  ┌──────────────────────────▼──────────────────────────────────┐   │
-│  │                    Supabase (BaaS)                          │   │
-│  │  ┌─────────────┐  ┌──────────────┐  ┌──────────────────┐  │   │
-│  │  │ PostgreSQL  │  │ Auth (JWT)   │  │ Storage (S3)     │  │   │
-│  │  │ Database    │  │ OAuth2       │  │ .riv files       │  │   │
-│  │  │ - users     │  │ Apple Sign-In│  │ .lottie files    │  │   │
-│  │  │ - projects  │  │ Google OAuth │  │ MP4 exports      │  │   │
-│  │  │ - courses   │  │ Email/Pass   │  │ Thumbnails       │  │   │
-│  │  │ - templates │  └──────────────┘  │ User assets      │  │   │
-│  │  │ - emotions  │                     └──────────────────┘  │   │
-│  │  └─────────────┘  ┌──────────────┐                          │   │
-│  │                    │  Realtime    │                          │   │
-│  │                    │  (PostgREST  │                          │   │
-│  │                    │   + WS)      │                          │   │
-│  │                    └──────────────┘                          │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                       │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │                Python AI Service (Phase 3)                   │   │
-│  │  FastAPI + Manim + FFmpeg + OpenAI API                      │   │
-│  │  - Receives emotion script as input                         │   │
-│  │  - Generates Manim code via LLM                             │   │
-│  │  - Renders video                                             │   │
-│  │  - Uploads to Storage                                        │   │
-│  └──────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────┐
+│               Client Layer                          │
+│  Flutter App (iOS · Android · Web · Desktop)        │
+│                                                     │
+│  Navigator 2.0 / MaterialPageRoute (MaterialRouter) │
+│  flutter_bloc (BLoC pattern)                        │
+└──────────────────┬─────────────────────────────────┘
+                   │ HTTPS / WebSocket
+┌──────────────────▼─────────────────────────────────┐
+│               Backend Layer                         │
+│  Supabase BaaS                                      │
+│  ├── PostgreSQL (users, courses, modules, reviews)  │
+│  ├── Auth (JWT)                                     │
+│  ├── Storage (thumbnails, Rive files)               │
+│  ├── Realtime                                       │
+│  └── Edge Functions (Deno)                         │
+│       ├── register                                  │
+│       ├── courses                                   │
+│       └── reviews                                   │
+└────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## Flutter App Architecture
-
-### Clean Architecture with Riverpod
+## Flutter App: Clean Architecture + BLoC
 
 ```
 lib/
-├── main.dart
-├── app.dart                    # App root, GoRouter config
-│
+├── main.dart                    # App entry point, MultiBlocProvider
 ├── core/
-│   ├── constants/
-│   │   ├── app_colors.dart
-│   │   ├── app_typography.dart
-│   │   └── emotion_types.dart  # All emotion tag definitions
-│   ├── utils/
-│   │   ├── emotion_parser.dart  # Parse [EMOTION:xxx] tags from script
-│   │   ├── script_compiler.dart # Compile script to animation timeline
-│   │   └── video_exporter.dart  # FFmpeg export logic
-│   └── widgets/                 # Shared UI components
-│       ├── emotion_tag_chip.dart
-│       ├── course_card.dart
-│       └── animated_loader.dart
-│
-├── features/
-│   ├── auth/
-│   │   ├── data/
-│   │   │   └── auth_repository.dart
-│   │   ├── domain/
-│   │   │   └── auth_provider.dart
-│   │   └── presentation/
-│   │       ├── login_screen.dart
-│   │       └── signup_screen.dart
-│   │
-│   ├── showcase/               # Витрина feature
-│   │   ├── data/
-│   │   │   └── courses_repository.dart
-│   │   ├── domain/
-│   │   │   ├── models/course.dart
-│   │   │   └── showcase_provider.dart
-│   │   └── presentation/
-│   │       ├── showcase_screen.dart
-│   │       ├── course_detail_screen.dart
-│   │       └── widgets/
-│   │           ├── course_grid.dart
-│   │           └── featured_banner.dart
-│   │
-│   ├── player/                 # Video Player feature
-│   │   ├── data/
-│   │   │   └── playback_repository.dart
-│   │   ├── domain/
-│   │   │   └── player_provider.dart
-│   │   └── presentation/
-│   │       ├── player_screen.dart
-│   │       └── widgets/
-│   │           ├── animation_canvas.dart  # Rive canvas
-│   │           ├── progress_bar.dart
-│   │           └── scene_timeline.dart
-│   │
-│   ├── editor/                 # Script-Emotion Editor feature
-│   │   ├── data/
-│   │   │   └── project_repository.dart
-│   │   ├── domain/
-│   │   │   ├── models/
-│   │   │   │   ├── emotion_script.dart
-│   │   │   │   ├── scene.dart
-│   │   │   │   └── timeline.dart
-│   │   │   └── editor_provider.dart
-│   │   └── presentation/
-│   │       ├── editor_screen.dart
-│   │       └── widgets/
-│   │           ├── script_text_field.dart   # Quill editor
-│   │           ├── preview_canvas.dart       # Live Rive preview
-│   │           ├── emotion_picker.dart       # Tag inserter
-│   │           └── timeline_bar.dart
-│   │
-│   └── emotions/               # Emotion Library feature
-│       ├── data/
-│       │   └── emotions_repository.dart
-│       ├── domain/
-│       │   └── emotions_provider.dart
-│       └── presentation/
-│           ├── emotion_library_screen.dart
-│           └── widgets/
-│               ├── emotion_card.dart
-│               └── emotion_preview.dart
-│
-└── l10n/                       # Localization
-    ├── app_en.arb
-    └── app_ru.arb
+│   ├── theme/
+│   │   └── app_theme.dart       # Dark theme, AppColors
+│   ├── router/
+│   │   └── app_router.dart      # MaterialRouter — onGenerateRoute
+│   └── supabase/
+│       └── supabase_config.dart # URL + anon key constants
+└── features/
+    ├── auth/
+    │   ├── bloc/
+    │   │   ├── auth_bloc.dart   # AuthBloc
+    │   │   ├── auth_event.dart
+    │   │   └── auth_state.dart
+    │   ├── repository/
+    │   │   └── auth_repository.dart
+    │   └── screens/
+    │       └── registration_screen.dart
+    ├── showcase/
+    │   ├── bloc/
+    │   │   ├── showcase_bloc.dart
+    │   │   ├── showcase_event.dart
+    │   │   └── showcase_state.dart
+    │   ├── models/
+    │   │   └── course.dart      # Course, CourseModule, demo seed data
+    │   ├── screens/
+    │   │   └── showcase_screen.dart
+    │   └── widgets/
+    │       └── course_card.dart
+    ├── player/
+    │   ├── bloc/
+    │   │   ├── player_bloc.dart
+    │   │   ├── player_event.dart
+    │   │   └── player_state.dart
+    │   ├── models/
+    │   │   └── emotion_script_parser.dart
+    │   ├── screens/
+    │   │   └── player_screen.dart
+    │   └── widgets/
+    │       └── emotion_avatar.dart
+    └── review/
+        ├── bloc/
+        │   ├── review_bloc.dart
+        │   ├── review_event.dart
+        │   └── review_state.dart
+        └── screens/
+            └── review_screen.dart
 ```
 
 ---
 
-## Data Flow: Script → Animation
+## Navigation (MaterialRouter)
+
+Navigation is handled by Flutter's built-in `Navigator` using `MaterialPageRoute`
+and `PageRouteBuilder` (for custom fade/slide transitions). Route names are
+constants in `AppRoutes`.
 
 ```
-User types script in Editor
-         │
-         ▼
-EmotionParser.parse(scriptText)
-         │
-         ▼
-ScriptAST {
-  segments: [
-    TextSegment("Here is how..."),
-    EmotionSegment(type: "typing_code"),
-    CodeSegment(language: "python", code: "x = 42"),
-    EmotionSegment(type: "box_appear", params: {name: "x", value: 42}),
-    EmotionSegment(type: "confetti")
-  ]
-}
-         │
-         ▼
-TimelineCompiler.compile(ast)
-         │
-         ▼
-AnimationTimeline {
-  totalDuration: 45.0, // seconds
-  tracks: [
-    AudioTrack(tts_audio_url, start: 0.0),
-    RiveTrack(scene: "box_metaphor", triggers: [...]),
-    SubtitleTrack(segments: [...])
-  ]
-}
-         │
-         ▼
-AnimationCanvas (Rive + CustomPainter)
-renders each frame at 60fps
-         │
-         ▼
-[Export] → FFmpeg captures canvas → MP4
+AppRoutes.registration  →  RegistrationScreen
+         ↓ (pushReplacementNamed after login)
+AppRoutes.showcase      →  ShowcaseScreen
+         ↓ (pushNamed with courseId argument)
+AppRoutes.player        →  PlayerScreen(courseId)
+         ↓ (pushReplacementNamed after last module)
+AppRoutes.review        →  ReviewScreen(courseId)
+         ↓ (pushNamedAndRemoveUntil after submit/skip)
+AppRoutes.showcase      →  ShowcaseScreen
 ```
+
+> **Why MaterialRouter over GoRouter?**
+> GoRouter adds a dependency and its own opinionated layer. For a focused demo
+> with a linear flow, Flutter's built-in Navigator is simpler, has zero extra
+> dependencies, and gives full control over transition animations.
 
 ---
 
-## Emotion Script Processing
+## State Management (BLoC)
 
-### Parser (Dart)
+Each feature has its own BLoC:
 
-```dart
-class EmotionParser {
-  static final _emotionTagRegex = RegExp(
-    r'\[EMOTION:(\w+)(?:\s+([^\]]*))?\]',
-    multiLine: true,
-  );
+| BLoC | Events | Key States |
+|------|--------|------------|
+| `AuthBloc` | `AuthPasswordGenerated`, `AuthLoginRequested`, `AuthReset` | `initial` → `generatingPassword` → `loading` → `success/failure` |
+| `ShowcaseBloc` | `ShowcaseLoadCourses`, `ShowcaseCourseSelected` | `loading` → `success` |
+| `PlayerBloc` | `PlayerLoadCourse`, `PlayerAdvanceSegment`, `PlayerGoToModule`, `PlayerTogglePlayback`, `PlayerCourseCompleted` | `loading` → `playing` → `moduleComplete` → `courseComplete` |
+| `ReviewBloc` | `ReviewRatingChanged`, `ReviewTextChanged`, `ReviewSubmitted` | `initial` → `submitting` → `success` |
 
-  static final _codeTagRegex = RegExp(
-    r'\[CODE:(\w+)\](.*?)\[/CODE\]',
-    multiLine: true,
-    dotAll: true,
-  );
-
-  List<ScriptSegment> parse(String script) {
-    final segments = <ScriptSegment>[];
-    var lastEnd = 0;
-
-    for (final match in _emotionTagRegex.allMatches(script)) {
-      // Add text before this tag
-      if (match.start > lastEnd) {
-        segments.add(TextSegment(script.substring(lastEnd, match.start)));
-      }
-
-      final emotionType = match.group(1)!;
-      final paramsStr = match.group(2) ?? '';
-      final params = _parseParams(paramsStr);
-      segments.add(EmotionSegment(type: emotionType, params: params));
-
-      lastEnd = match.end;
-    }
-
-    // Remaining text
-    if (lastEnd < script.length) {
-      segments.add(TextSegment(script.substring(lastEnd)));
-    }
-
-    return segments;
-  }
-}
-```
+> **Why BLoC over Riverpod?**
+> BLoC enforces a strict unidirectional data flow with explicit events and
+> states, making the demo flow auditable and testable with `bloc_test`.
 
 ---
 
-## Database Schema (PostgreSQL / Supabase)
+## Emotion-Script Format
 
-```sql
--- Users
-CREATE TABLE users (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  email TEXT UNIQUE NOT NULL,
-  display_name TEXT,
-  avatar_url TEXT,
-  plan TEXT DEFAULT 'free', -- free, creator, pro, team
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
+```
+[EMOTION:name]   — triggers animation state in the EmotionAvatar
+[CODE:lang]      — opens a code block
+[/CODE]          — closes a code block
+plain text       — narration text shown as subtitle card
+```
 
--- Courses (published)
-CREATE TABLE courses (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  creator_id UUID REFERENCES users(id),
-  title TEXT NOT NULL,
-  description TEXT,
-  thumbnail_url TEXT,
-  duration_seconds INT,
-  level TEXT, -- beginner, intermediate, advanced
-  tags TEXT[],
-  is_published BOOLEAN DEFAULT FALSE,
-  view_count INT DEFAULT 0,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW()
-);
+`EmotionScriptParser` parses these tags into a flat `List<ScriptSegment>`:
+`EmotionSegment | NarrationSegment | CodeSegment`.
 
--- Modules (course sections)
-CREATE TABLE modules (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  course_id UUID REFERENCES courses(id) ON DELETE CASCADE,
-  title TEXT NOT NULL,
-  position INT NOT NULL,
-  duration_seconds INT,
-  animation_url TEXT,   -- .riv or MP4 URL
-  script_json JSONB     -- compiled animation timeline
-);
+In production the `EmotionAvatar` widget drives a Rive `StateMachineController`
+with the named emotion input. For the demo it uses animated emoji containers.
 
--- Projects (drafts / in-progress)
-CREATE TABLE projects (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  creator_id UUID REFERENCES users(id),
-  title TEXT NOT NULL,
-  emotion_script TEXT,  -- raw script text
-  compiled_json JSONB,  -- compiled timeline
-  status TEXT DEFAULT 'draft', -- draft, compiling, ready, published
-  updated_at TIMESTAMPTZ DEFAULT NOW()
-);
+---
 
--- Emotion Templates
-CREATE TABLE emotion_templates (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  name TEXT NOT NULL,
-  type TEXT NOT NULL,   -- e.g. "box_appear", "code_reveal"
-  category TEXT,        -- narrator, code, concept, reaction, transition
-  rive_asset_url TEXT,
-  params_schema JSONB,  -- JSON Schema for emotion parameters
-  preview_gif_url TEXT,
-  is_premium BOOLEAN DEFAULT FALSE,
-  created_by UUID REFERENCES users(id)
-);
+## Supabase Edge Functions (Deno)
 
--- User Progress
-CREATE TABLE user_progress (
-  user_id UUID REFERENCES users(id),
-  course_id UUID REFERENCES courses(id),
-  last_module_id UUID REFERENCES modules(id),
-  completed_modules UUID[],
-  progress_percent FLOAT DEFAULT 0,
-  completed_at TIMESTAMPTZ,
-  PRIMARY KEY (user_id, course_id)
-);
+| Function | Method | Purpose |
+|----------|--------|---------|
+| `register` | POST | Create auth user + `users` row, skip email confirmation |
+| `courses` | GET | List/search published courses |
+| `reviews` | POST | Upsert review, recalculate course average rating |
+
+Environment variables required:
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+---
+
+## Demo User Journey
+
+```
+1. Registration  →  RegistrationScreen
+   • Enter email
+   • Auto-generated password shown + copy button
+   • Tap "Войти и начать" → Supabase auth.signUp
+
+2. Showcase      →  ShowcaseScreen
+   • Course card: "Выучи Python за 1 час"
+   • Tap card → navigate to Player
+
+3. Player        →  PlayerScreen
+   • EmotionAvatar reacts to [EMOTION:xxx] tags
+   • NarrationSegment shown as text card
+   • CodeSegment shown as syntax-highlighted block
+   • "Далее →" advances segments; "Следующий модуль" moves to next module
+
+4. Review        →  ReviewScreen
+   • Star rating (1-5) via flutter_rating_bar
+   • Optional text review
+   • Submit → Supabase Edge Function "reviews"
+   • Back to Showcase
 ```

--- a/idea/flutter-libraries.md
+++ b/idea/flutter-libraries.md
@@ -1,293 +1,112 @@
-# Flutter Libraries: Complete Dependency List
+# Flutter Libraries: Dependency List
 
-## pubspec.yaml
+> **Updated per issue #3**:
+> - `go_router` **removed** → replaced by Flutter's built-in `Navigator` / `MaterialPageRoute`
+> - `flutter_riverpod` / `riverpod_annotation` **removed** → replaced by `flutter_bloc` / `bloc`
+
+---
+
+## pubspec.yaml (demo app)
 
 ```yaml
 name: animalearn
-description: 2D Content Factory for Educational Videos
-version: 1.0.0+1
+description: AnimaLearn - 2D Content Factory for emotion-script driven learning
+version: 0.1.0+1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
 
-  # ============================================================
-  # ANIMATION & CANVAS (Core Product)
-  # ============================================================
+  # State Management (BLoC — replaces Riverpod per issue #3)
+  flutter_bloc: ^8.1.6
+  bloc: ^8.1.4
+  equatable: ^2.0.5
 
-  # Rive: Interactive 2D animation engine (PRIMARY ENGINE)
-  # Used for: All pre-built emotion animations, scene templates
-  # Why: State machine support, 15x smaller files vs video, Flutter-native
+  # Backend & API
+  supabase_flutter: ^2.5.0
+  dio: ^5.7.0
+
+  # Animation & Canvas
   rive: ^0.13.0
-
-  # Lottie: JSON animation player (SECONDARY - decorative)
-  # Used for: Loading states, decorative overlays, onboarding
-  # Why: Huge library of free animations (LottieFiles.com)
   lottie: ^3.1.0
-
-  # flutter_animate: Code-driven widget animations
-  # Used for: UI transitions, element reveals, micro-interactions
-  # Why: Clean API, chain animations easily
   flutter_animate: ^4.5.0
 
-  # Flame: 2D game engine for complex scenes
-  # Used for: Advanced canvas scenes (game-like animations)
-  # Why: CustomPainter on steroids; Rive integration built-in
-  flame: ^1.18.0
+  # UI Components
+  shimmer: ^3.0.0
+  smooth_page_indicator: ^1.2.0
+  flutter_rating_bar: ^4.0.1
 
-  # flutter_svg: SVG rendering
-  # Used for: Vector asset library, custom illustrations
-  # Why: Crisp at any size; editable fill/stroke colors
-  flutter_svg: ^2.0.0
-
-  # graphx: DisplayObject canvas API (Flash-like)
-  # Used for: Advanced programmatic 2D drawings
-  # Why: More intuitive than raw CustomPainter
-  graphx: ^0.9.0
-
-  # drawing_animation: SVG path drawing animation
-  # Used for: "Writing" effect for text/diagrams
-  # Why: Perfect for "diagram appearing" animations
-  drawing_animation: ^2.0.0
-
-  # animations: Material Design motion specs
-  # Used for: Screen transitions, container transforms
-  # Why: Official Flutter package, well-tested
-  animations: ^2.0.11
-
-  # ============================================================
-  # CONTENT AUTHORING (Script-Emotion Editor)
-  # ============================================================
-
-  # flutter_quill: Rich text editor
-  # Used for: Main script authoring editor
-  # Why: Most mature WYSIWYG editor for Flutter
-  flutter_quill: ^10.8.0
-
-  # flutter_markdown: Markdown rendering
-  # Used for: Preview mode, documentation
-  flutter_markdown: ^0.7.4
-
-  # flutter_highlight: Code syntax highlighting
-  # Used for: Inline code blocks in scripts
-  # Why: Supports 100+ languages including Python, JS, Dart
-  flutter_highlight: ^0.7.0
-
-  # re_editor: Advanced code editor widget
-  # Used for: Code emotion blocks in editor
-  # Why: Better than TextField for code; supports brackets, indent
-  re_editor: ^0.3.0
-
-  # ============================================================
-  # MEDIA & VIDEO
-  # ============================================================
-
-  # video_player: Video playback
-  # Used for: Playing generated/uploaded video courses
-  video_player: ^2.9.0
-
-  # chewie: Video player UI
-  # Used for: Full-featured player controls
-  chewie: ^1.8.1
-
-  # ffmpeg_kit_flutter: Video processing
-  # Used for: Exporting Flutter canvas to MP4
-  # Why: Production-tested; runs on device; no server needed for basic export
-  ffmpeg_kit_flutter: ^6.0.3
-
-  # image: Image processing
-  # Used for: Thumbnail generation, image manipulation
-  image: ^4.2.0
-
-  # just_audio: Audio playback
-  # Used for: Narration audio, sound effects
-  just_audio: ^0.9.39
-
-  # record: Audio recording
-  # Used for: Voiceover recording in editor
-  record: ^5.1.0
-
-  # ============================================================
-  # UI COMPONENTS
-  # ============================================================
-
-  # Showcase layout
-  flutter_staggered_grid_view: ^0.7.0   # Masonry grid for course cards
-  infinite_scroll_pagination: ^4.0.0    # Paginated course lists
-
-  # Animated lists
-  flutter_staggered_animations: ^1.1.1  # Staggered entrance animations
-
-  # Loading
-  shimmer: ^3.0.0                        # Skeleton loading screens
-
-  # Editor UI
-  flutter_colorpicker: ^1.1.0            # Color picker for scene backgrounds
-  dotted_border: ^2.1.0                  # Canvas selection borders
-
-  # Progress & indicators
-  smooth_page_indicator: ^1.2.0          # Module progress indicator
-  percent_indicator: ^4.2.3              # Circular/linear progress bars
-
-  # Icons
-  iconsax: ^0.0.8                        # Modern icon set (500+ icons)
-  hugeicons: ^0.0.7                      # Large icon library (4000+ icons)
-
-  # Tooltips & help
-  showcaseview: ^3.0.0                   # Feature discovery tooltips
-  super_tooltip: ^2.0.5                  # Contextual tooltips
-
-  # Bottom sheets & dialogs
-  modal_bottom_sheet: ^3.0.0             # Smooth bottom sheets
-  flutter_slidable: ^3.1.0              # Swipe actions on list items
-
-  # Drag & drop
-  reorderable_grid_view: ^2.2.8          # Drag-reorder grid (timeline)
-  drag_and_drop_lists: ^0.4.3            # Drag-reorder lists
-
-  # ============================================================
-  # STATE MANAGEMENT & ARCHITECTURE
-  # ============================================================
-
-  # Riverpod: Reactive state management
-  flutter_riverpod: ^2.5.1
-  riverpod_annotation: ^2.3.5
-
-  # Immutable data classes
+  # Data / Serialization
   freezed_annotation: ^2.4.4
   json_annotation: ^4.9.0
 
-  # ============================================================
-  # LOCAL STORAGE & DATABASE
-  # ============================================================
+  # Utilities
+  uuid: ^4.4.0
+  intl: ^0.19.0
+  logger: ^2.4.0
+  shared_preferences: ^2.3.2
 
-  # Hive: Fast key-value store
-  # Used for: User preferences, draft cache, offline courses
-  hive_flutter: ^1.1.0
-
-  # Drift: SQLite ORM
-  # Used for: Projects database, course content, emotion library
-  drift: ^2.18.0
-  sqlite3_flutter_libs: ^0.5.0
-
-  # SharedPreferences: Simple settings
-  shared_preferences: ^2.2.3
-
-  # ============================================================
-  # BACKEND & API
-  # ============================================================
-
-  # Supabase: Open-source backend (Firebase alternative)
-  # Used for: Auth, database, file storage, real-time
-  supabase_flutter: ^2.5.0
-
-  # HTTP client
-  dio: ^5.7.0
-  retrofit: ^4.1.0             # Type-safe HTTP with code gen
-
-  # Real-time collaboration (Phase 2)
-  web_socket_channel: ^3.0.1
-
-  # ============================================================
-  # NAVIGATION
-  # ============================================================
-
-  go_router: ^14.2.7           # Declarative routing with deep links
-
-  # ============================================================
-  # UTILITIES
-  # ============================================================
-
-  # File handling
-  path_provider: ^2.1.4        # File system paths
-  path: ^1.9.0                 # Path utilities
-  file_picker: ^8.0.3          # File selection dialog
-  image_picker: ^1.1.2         # Camera/gallery picker
-
-  # Sharing
-  share_plus: ^10.0.0          # Native share dialog
-  url_launcher: ^6.3.1         # Open URLs
-
-  # Permissions
-  permission_handler: ^11.3.1  # Runtime permission requests
-
-  # Connectivity
-  connectivity_plus: ^6.0.3    # Network status
-
-  # Localization
-  intl: ^0.19.0                # i18n & date formatting
-
-  # Crypto & security
-  crypto: ^3.0.5               # Hashing
-  flutter_secure_storage: ^9.2.2 # Secure token storage
-
-  # Analytics
-  mixpanel_flutter: ^2.3.1     # User analytics (optional)
-
-  # UUID generation
-  uuid: ^4.4.0                 # Generate unique IDs
-
-  # Logger
-  logger: ^2.4.0               # Structured logging
+  cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # Code generation
-  build_runner: ^2.4.13
-  freezed: ^2.5.2
+  build_runner: ^2.4.12
+  freezed: ^2.5.7
   json_serializable: ^6.8.0
-  riverpod_generator: ^2.4.3
-  drift_dev: ^2.18.0
-  retrofit_generator: ^8.1.0
-
-  # Linting
-  flutter_lints: ^4.0.0
-  custom_lint: ^0.6.7
-  riverpod_lint: ^2.3.13
-
-  # Testing
+  bloc_test: ^9.1.7
   mocktail: ^1.0.4
-  flutter_test:
-    sdk: flutter
-  integration_test:
-    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/animations/
+    - assets/images/
 ```
 
 ---
 
-## Library Selection Rationale
+## Library Rationale
 
-### Why Rive over other animation engines?
-1. **State machine**: Animations respond to real-time data (e.g., emotion changes)
-2. **File size**: `.riv` files are 10–15x smaller than equivalent video
-3. **Flutter-native**: Official Flutter runtime with full platform support
-4. **Editor**: Free online editor at rive.app for creating templates
-5. **Interactivity**: Can receive input events (tap, hover, data changes)
+### State Management: flutter_bloc
 
-### Why Supabase over Firebase?
-1. **Open-source**: Can self-host if needed; no vendor lock-in
-2. **PostgreSQL**: Full SQL capabilities vs Firestore's limited queries
-3. **Realtime**: Built-in PostgreSQL LISTEN/NOTIFY for live updates
-4. **Storage**: S3-compatible storage with CDN
-5. **Auth**: Row-level security policies
+`flutter_bloc` (BLoC pattern) was chosen per issue #3 requirements.
 
-### Why Riverpod over Bloc/GetX?
-1. **Type-safe**: Compile-time errors instead of runtime
-2. **Testable**: Providers are easy to mock and test
-3. **Code generation**: Less boilerplate with riverpod_generator
-4. **No BuildContext**: Providers accessible anywhere, not just widget tree
-5. **Flutter 3.x optimized**: Built for modern Flutter patterns
+**Advantages over Riverpod for this project:**
+- Explicit events → states: every state change is auditable
+- `bloc_test` makes unit tests for each BLoC straightforward
+- Well-defined separation: UI dispatches events, BLoC handles logic
+- Industry-standard for Flutter enterprise apps
 
-### Why ffmpeg_kit_flutter for video export?
-1. **On-device**: No server needed for basic MP4 export
-2. **Production-tested**: Used by major video apps
-3. **Cross-platform**: Works on iOS, Android, macOS
-4. **Full FFmpeg**: All FFmpeg filters and codecs available
+### Navigation: MaterialRouter (built-in)
+
+`go_router` was removed per issue #3 requirements.
+
+Flutter's built-in `Navigator` with `onGenerateRoute` provides:
+- Zero additional dependency
+- Full custom transition animations via `PageRouteBuilder`
+- Simple linear flow for the demo (registration → showcase → player → review)
+
+### Animation: rive + flutter_animate
+
+- `rive` — drives 2D character animations via StateMachineController.
+  Emotion tags trigger named inputs (e.g. `excited`, `happy`) in the Rive file.
+- `flutter_animate` — lightweight declarative micro-animations for UI elements
+  (fade-in, slide, scale on entrance).
+- `lottie` — hero banners and loading/celebration animations.
+
+### Backend: supabase_flutter
+
+Supabase provides a complete BaaS (Auth, PostgreSQL, Storage, Realtime, Edge
+Functions) without the vendor lock-in of Firebase. The Dart SDK wraps REST and
+WebSocket transport transparently.
+
+### Testing: bloc_test + mocktail
+
+- `bloc_test` provides `blocTest<B, S>()` — a clean DSL for testing BLoC
+  event → state sequences.
+- `mocktail` offers null-safe mocking via `Mock` / `when()` without code gen.

--- a/idea/screens/00-navigation.md
+++ b/idea/screens/00-navigation.md
@@ -1,105 +1,76 @@
 # Navigation Structure: AnimaLearn
 
-## App Navigation Map
+> **Updated per issue #3**: GoRouter replaced by Flutter's built-in
+> `Navigator` + `MaterialPageRoute` (MaterialRouter). No external routing
+> library dependency.
+
+---
+
+## Demo App Navigation Map
 
 ```
 App Entry
     │
-    ├── [Not authenticated] → Onboarding → Auth Flow
-    │
-    └── [Authenticated] → Main Shell
-              │
-              ├── Bottom Nav Tab 1: Showcase (Витрина)       [01-showcase]
-              │       └── Course Detail → Player             [02-player, 03-player]
-              │
-              ├── Bottom Nav Tab 2: My Learning
-              │       └── In-Progress Courses → Player
-              │
-              ├── Bottom Nav Tab 3: Create (Editor)          [04-editor]
-              │       ├── New Project
-              │       ├── Edit Project → Editor Screen
-              │       └── Emotion Library                    [05-emotion-library]
-              │
-              └── Bottom Nav Tab 4: Profile
-                      ├── My Courses (published)
-                      ├── Analytics
-                      └── Settings
+    └── RegistrationScreen  (AppRoutes.registration = '/')
+           │
+           │ [after successful login]
+           │ Navigator.pushReplacementNamed
+           ▼
+        ShowcaseScreen  (AppRoutes.showcase = '/showcase')
+           │
+           │ [tap course card]
+           │ Navigator.pushNamed(arguments: courseId)
+           ▼
+        PlayerScreen  (AppRoutes.player = '/player')
+           │
+           │ [after last module completes]
+           │ Navigator.pushReplacementNamed(arguments: courseId)
+           ▼
+        ReviewScreen  (AppRoutes.review = '/review')
+           │
+           │ [submit or skip]
+           │ Navigator.pushNamedAndRemoveUntil
+           ▼
+        ShowcaseScreen  (back to catalog)
 ```
 
-## Route Definitions (GoRouter)
+---
+
+## Route Definitions
+
+Routes are defined as string constants in `AppRoutes` and resolved in
+`AppRouter.onGenerateRoute` (passed to `MaterialApp.onGenerateRoute`).
 
 ```dart
-final router = GoRouter(
-  routes: [
-    // Auth
-    GoRoute(path: '/onboarding', builder: (_,__) => OnboardingScreen()),
-    GoRoute(path: '/login', builder: (_,__) => LoginScreen()),
-    GoRoute(path: '/signup', builder: (_,__) => SignupScreen()),
-
-    // Main shell with bottom nav
-    ShellRoute(
-      builder: (_, __, child) => MainShell(child: child),
-      routes: [
-        // Showcase (Витрина)
-        GoRoute(
-          path: '/showcase',
-          builder: (_, __) => ShowcaseScreen(),
-          routes: [
-            GoRoute(
-              path: 'course/:courseId',
-              builder: (_, state) => CourseDetailScreen(
-                courseId: state.pathParameters['courseId']!,
-              ),
-              routes: [
-                GoRoute(
-                  path: 'play/:moduleId',
-                  builder: (_, state) => PlayerScreen(
-                    courseId: state.pathParameters['courseId']!,
-                    moduleId: state.pathParameters['moduleId']!,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-
-        // My Learning
-        GoRoute(path: '/learning', builder: (_, __) => MyLearningScreen()),
-
-        // Create (Editor)
-        GoRoute(
-          path: '/create',
-          builder: (_, __) => MyProjectsScreen(),
-          routes: [
-            GoRoute(
-              path: 'new',
-              builder: (_, __) => EditorScreen(),
-            ),
-            GoRoute(
-              path: 'edit/:projectId',
-              builder: (_, state) => EditorScreen(
-                projectId: state.pathParameters['projectId'],
-              ),
-            ),
-            GoRoute(
-              path: 'emotions',
-              builder: (_, __) => EmotionLibraryScreen(),
-            ),
-          ],
-        ),
-
-        // Profile
-        GoRoute(path: '/profile', builder: (_, __) => ProfileScreen()),
-      ],
-    ),
-  ],
-);
+class AppRoutes {
+  static const registration = '/';
+  static const showcase     = '/showcase';
+  static const player       = '/player';
+  static const review       = '/review';
+}
 ```
 
-## Navigation Design Principles
+Arguments are passed via `RouteSettings.arguments` (typed as `String?`
+for `courseId`).
 
-1. **Deep linking**: Every course and module has a shareable URL
-2. **Back navigation**: Physical back button always works as expected
-3. **State preservation**: Bottom nav tabs preserve scroll position
-4. **Transition animations**: Material motion specs for screen transitions
-5. **Offline fallback**: When offline, show cached content or graceful error
+---
+
+## Transition Animations
+
+| Route | Transition |
+|-------|-----------|
+| `registration` | Fade (300 ms) |
+| `showcase` | Slide from right (380 ms, easeInOutCubic) |
+| `player` | Slide from right (380 ms, easeInOutCubic) |
+| `review` | Slide from right (380 ms, easeInOutCubic) |
+
+---
+
+## Why MaterialRouter over GoRouter
+
+GoRouter was removed per issue #3 requirements. Flutter's built-in Navigator:
+
+- Zero extra dependencies
+- Full control over transition animations via `PageRouteBuilder`
+- No configuration overhead for a linear demo flow
+- Easy to extend: add `onGenerateRoute` cases as new screens are added

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:animalearn/features/auth/screens/registration_screen.dart';
+import 'package:animalearn/features/showcase/screens/showcase_screen.dart';
+import 'package:animalearn/features/player/screens/player_screen.dart';
+import 'package:animalearn/features/review/screens/review_screen.dart';
+
+/// MaterialRouter — Navigator 2.0 style routing using [Navigator] and
+/// [MaterialPageRoute]. Replaces GoRouter (removed per issue #3).
+///
+/// Route names are defined as constants to avoid magic strings across the app.
+class AppRoutes {
+  static const registration = '/';
+  static const showcase = '/showcase';
+  static const player = '/player';
+  static const review = '/review';
+}
+
+class AppRouter {
+  /// Generates a [Route] for the given [RouteSettings].
+  ///
+  /// Used as [MaterialApp.onGenerateRoute].
+  static Route<dynamic> onGenerateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case AppRoutes.registration:
+        return _fade(const RegistrationScreen());
+
+      case AppRoutes.showcase:
+        return _slide(const ShowcaseScreen());
+
+      case AppRoutes.player:
+        final courseId = settings.arguments as String? ?? 'python-1h';
+        return _slide(PlayerScreen(courseId: courseId));
+
+      case AppRoutes.review:
+        final courseId = settings.arguments as String? ?? 'python-1h';
+        return _slide(ReviewScreen(courseId: courseId));
+
+      default:
+        return _fade(const RegistrationScreen());
+    }
+  }
+
+  static PageRouteBuilder _fade(Widget page) {
+    return PageRouteBuilder(
+      pageBuilder: (_, __, ___) => page,
+      transitionsBuilder: (_, animation, __, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+      transitionDuration: const Duration(milliseconds: 300),
+    );
+  }
+
+  static PageRouteBuilder _slide(Widget page) {
+    return PageRouteBuilder(
+      pageBuilder: (_, __, ___) => page,
+      transitionsBuilder: (_, animation, __, child) {
+        final tween = Tween(
+          begin: const Offset(1.0, 0.0),
+          end: Offset.zero,
+        ).chain(CurveTween(curve: Curves.easeInOutCubic));
+        return SlideTransition(position: animation.drive(tween), child: child);
+      },
+      transitionDuration: const Duration(milliseconds: 380),
+    );
+  }
+}

--- a/lib/core/supabase/supabase_config.dart
+++ b/lib/core/supabase/supabase_config.dart
@@ -1,0 +1,22 @@
+/// Supabase configuration constants.
+/// Replace [supabaseUrl] and [supabaseAnonKey] with your actual project values
+/// from the Supabase dashboard (Settings → API).
+class SupabaseConfig {
+  static const supabaseUrl = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: 'https://your-project-ref.supabase.co',
+  );
+
+  static const supabaseAnonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+    defaultValue: 'your-anon-key',
+  );
+
+  // Edge Function base path
+  static const functionsBase = '$supabaseUrl/functions/v1';
+
+  // Edge Function endpoints
+  static const registerFn = '$functionsBase/register';
+  static const coursesFn = '$functionsBase/courses';
+  static const reviewsFn = '$functionsBase/reviews';
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const primary = Color(0xFF6366F1); // Indigo
+  static const secondary = Color(0xFFF59E0B); // Amber
+  static const background = Color(0xFF0F0F13);
+  static const surface = Color(0xFF1A1A24);
+  static const surfaceVariant = Color(0xFF25253A);
+  static const onSurface = Color(0xFFE2E8F0);
+  static const onSurfaceMuted = Color(0xFF94A3B8);
+  static const success = Color(0xFF10B981);
+  static const error = Color(0xFFEF4444);
+  static const starColor = Color(0xFFFBBF24);
+}
+
+ThemeData buildAppTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: const ColorScheme.dark(
+      primary: AppColors.primary,
+      secondary: AppColors.secondary,
+      surface: AppColors.surface,
+      error: AppColors.error,
+    ),
+    scaffoldBackgroundColor: AppColors.background,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppColors.background,
+      elevation: 0,
+      centerTitle: true,
+      titleTextStyle: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.3,
+      ),
+      iconTheme: IconThemeData(color: AppColors.onSurface),
+    ),
+    cardTheme: CardTheme(
+      color: AppColors.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        minimumSize: const Size(double.infinity, 52),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+        ),
+        textStyle: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: AppColors.surfaceVariant,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(14),
+        borderSide: BorderSide.none,
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(14),
+        borderSide: BorderSide.none,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(14),
+        borderSide: const BorderSide(color: AppColors.primary, width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(14),
+        borderSide: const BorderSide(color: AppColors.error, width: 1),
+      ),
+      labelStyle: const TextStyle(color: AppColors.onSurfaceMuted),
+      hintStyle: const TextStyle(color: AppColors.onSurfaceMuted),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+    ),
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 32,
+        fontWeight: FontWeight.w700,
+      ),
+      headlineMedium: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 24,
+        fontWeight: FontWeight.w600,
+      ),
+      titleLarge: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+      ),
+      titleMedium: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 16,
+        fontWeight: FontWeight.w500,
+      ),
+      bodyLarge: TextStyle(
+        color: AppColors.onSurface,
+        fontSize: 16,
+      ),
+      bodyMedium: TextStyle(
+        color: AppColors.onSurfaceMuted,
+        fontSize: 14,
+      ),
+      labelSmall: TextStyle(
+        color: AppColors.onSurfaceMuted,
+        fontSize: 12,
+        letterSpacing: 0.4,
+      ),
+    ),
+  );
+}

--- a/lib/features/auth/bloc/auth_bloc.dart
+++ b/lib/features/auth/bloc/auth_bloc.dart
@@ -1,0 +1,85 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../repository/auth_repository.dart';
+
+part 'auth_event.dart';
+part 'auth_state.dart';
+
+/// BLoC for the fast-registration / login flow.
+///
+/// Flow:
+///   1. Screen loads → bloc generates a password and emits [AuthStatus.generatingPassword]
+///      with the [AuthState.generatedPassword] filled in so the UI can display it.
+///   2. User taps "Login" → [AuthLoginRequested] is dispatched.
+///   3. Bloc calls [AuthRepository.register] (or sign-in if already exists).
+///   4. On success → [AuthStatus.success] with [AuthState.userId].
+///   5. On failure → [AuthStatus.failure] with [AuthState.errorMessage].
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  AuthBloc({required this.repository}) : super(const AuthState()) {
+    on<AuthPasswordGenerated>(_onPasswordGenerated);
+    on<AuthLoginRequested>(_onLoginRequested);
+    on<AuthReset>(_onReset);
+  }
+
+  final AuthRepository repository;
+
+  void _onPasswordGenerated(
+    AuthPasswordGenerated event,
+    Emitter<AuthState> emit,
+  ) {
+    emit(state.copyWith(
+      status: AuthStatus.generatingPassword,
+      generatedPassword: event.password,
+    ));
+  }
+
+  Future<void> _onLoginRequested(
+    AuthLoginRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    final password = state.generatedPassword;
+    if (password == null || password.isEmpty) {
+      emit(state.copyWith(
+        status: AuthStatus.failure,
+        errorMessage: 'Password not generated yet.',
+      ));
+      return;
+    }
+
+    emit(state.copyWith(status: AuthStatus.loading));
+
+    try {
+      // Try register first; if the user already exists, sign in.
+      final user = await repository.register(
+        email: event.email,
+        password: password,
+      );
+      emit(state.copyWith(
+        status: AuthStatus.success,
+        userId: user.id,
+      ));
+    } catch (e) {
+      // Fall back to sign-in (demo: same auto-password)
+      try {
+        final user = await repository.signIn(
+          email: event.email,
+          password: password,
+        );
+        emit(state.copyWith(
+          status: AuthStatus.success,
+          userId: user.id,
+        ));
+      } catch (signInError) {
+        emit(state.copyWith(
+          status: AuthStatus.failure,
+          errorMessage: signInError.toString(),
+        ));
+      }
+    }
+  }
+
+  void _onReset(AuthReset event, Emitter<AuthState> emit) {
+    emit(const AuthState());
+  }
+}

--- a/lib/features/auth/bloc/auth_event.dart
+++ b/lib/features/auth/bloc/auth_event.dart
@@ -1,0 +1,33 @@
+part of 'auth_bloc.dart';
+
+abstract class AuthEvent extends Equatable {
+  const AuthEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// User typed an email and tapped "Login" — triggers auto-register + sign-in.
+class AuthLoginRequested extends AuthEvent {
+  const AuthLoginRequested({required this.email});
+
+  final String email;
+
+  @override
+  List<Object?> get props => [email];
+}
+
+/// Used to pre-fill the generated password field.
+class AuthPasswordGenerated extends AuthEvent {
+  const AuthPasswordGenerated({required this.password});
+
+  final String password;
+
+  @override
+  List<Object?> get props => [password];
+}
+
+/// Reset to initial state (e.g. sign-out).
+class AuthReset extends AuthEvent {
+  const AuthReset();
+}

--- a/lib/features/auth/bloc/auth_state.dart
+++ b/lib/features/auth/bloc/auth_state.dart
@@ -1,0 +1,44 @@
+part of 'auth_bloc.dart';
+
+enum AuthStatus { initial, generatingPassword, loading, success, failure }
+
+class AuthState extends Equatable {
+  const AuthState({
+    this.status = AuthStatus.initial,
+    this.generatedPassword,
+    this.userId,
+    this.errorMessage,
+  });
+
+  final AuthStatus status;
+
+  /// Auto-generated password shown to the user before they tap Login.
+  final String? generatedPassword;
+
+  /// Supabase user ID on success.
+  final String? userId;
+
+  final String? errorMessage;
+
+  AuthState copyWith({
+    AuthStatus? status,
+    String? generatedPassword,
+    String? userId,
+    String? errorMessage,
+  }) {
+    return AuthState(
+      status: status ?? this.status,
+      generatedPassword: generatedPassword ?? this.generatedPassword,
+      userId: userId ?? this.userId,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        generatedPassword,
+        userId,
+        errorMessage,
+      ];
+}

--- a/lib/features/auth/repository/auth_repository.dart
+++ b/lib/features/auth/repository/auth_repository.dart
@@ -1,0 +1,69 @@
+import 'package:logger/logger.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+final _log = Logger(printer: PrettyPrinter(methodCount: 0));
+
+/// Handles authentication operations via Supabase Auth.
+///
+/// For the demo the "fast registration" flow:
+///   1. User provides only their email.
+///   2. A random password is auto-generated and returned to the UI so the user
+///      can see it before logging in.
+///   3. If the email already exists we fall back to sign-in with the same
+///      auto-generated password (not realistic for production — demo only).
+class AuthRepository {
+  const AuthRepository();
+
+  final _supabase = Supabase.instance.client;
+
+  /// Generates a short, human-readable random password.
+  String generatePassword() {
+    final id = const Uuid().v4().replaceAll('-', '');
+    // Take first 10 chars and capitalise first letter for readability
+    final raw = id.substring(0, 10);
+    return '${raw[0].toUpperCase()}${raw.substring(1)}!';
+  }
+
+  /// Register with [email] and [password].
+  ///
+  /// Returns the signed-in [User] on success.
+  /// Throws a [AuthException] or generic [Exception] on failure.
+  Future<User> register({
+    required String email,
+    required String password,
+  }) async {
+    _log.d('Registering user: $email');
+    final response = await _supabase.auth.signUp(
+      email: email,
+      password: password,
+    );
+    final user = response.user;
+    if (user == null) {
+      throw Exception('Registration failed: no user returned');
+    }
+    _log.i('Registered user: ${user.id}');
+    return user;
+  }
+
+  /// Sign in with [email] and [password].
+  Future<User> signIn({
+    required String email,
+    required String password,
+  }) async {
+    _log.d('Signing in: $email');
+    final response = await _supabase.auth.signInWithPassword(
+      email: email,
+      password: password,
+    );
+    final user = response.user;
+    if (user == null) {
+      throw Exception('Sign-in failed: no user returned');
+    }
+    _log.i('Signed in: ${user.id}');
+    return user;
+  }
+
+  /// Returns the currently authenticated user, or null.
+  User? get currentUser => _supabase.auth.currentUser;
+}

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../../../core/router/app_router.dart';
+import '../../../core/theme/app_theme.dart';
+import '../bloc/auth_bloc.dart';
+
+/// Fast-registration screen.
+///
+/// Demo user journey step 1:
+///   • Single email input field.
+///   • Password is auto-generated and shown in a read-only field.
+///   • "Login" button triggers registration + sign-in via [AuthBloc].
+class RegistrationScreen extends StatefulWidget {
+  const RegistrationScreen({super.key});
+
+  @override
+  State<RegistrationScreen> createState() => _RegistrationScreenState();
+}
+
+class _RegistrationScreenState extends State<RegistrationScreen> {
+  final _emailController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    // Generate password immediately when the screen opens
+    final password =
+        context.read<AuthBloc>().repository.generatePassword();
+    context.read<AuthBloc>().add(AuthPasswordGenerated(password: password));
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _onLogin() {
+    if (!_formKey.currentState!.validate()) return;
+    context.read<AuthBloc>().add(
+          AuthLoginRequested(email: _emailController.text.trim()),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: BlocConsumer<AuthBloc, AuthState>(
+        listener: (context, state) {
+          if (state.status == AuthStatus.success) {
+            Navigator.of(context).pushReplacementNamed(AppRoutes.showcase);
+          } else if (state.status == AuthStatus.failure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.errorMessage ?? 'Authentication failed'),
+                backgroundColor: AppColors.error,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 40),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 24),
+                    // Logo / Brand
+                    _BrandHeader()
+                        .animate()
+                        .fadeIn(duration: 600.ms)
+                        .slideY(begin: -0.2, end: 0),
+                    const SizedBox(height: 48),
+
+                    // Headline
+                    Text(
+                      'Начать обучение',
+                      style: Theme.of(context).textTheme.headlineMedium,
+                    )
+                        .animate()
+                        .fadeIn(delay: 200.ms, duration: 500.ms)
+                        .slideX(begin: -0.1, end: 0),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Введите email — мы всё остальное сделаем за вас',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    )
+                        .animate()
+                        .fadeIn(delay: 300.ms, duration: 500.ms),
+                    const SizedBox(height: 36),
+
+                    // Email field
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      autocorrect: false,
+                      decoration: const InputDecoration(
+                        labelText: 'Email',
+                        prefixIcon: Icon(
+                          Icons.email_outlined,
+                          color: AppColors.onSurfaceMuted,
+                        ),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Введите email';
+                        }
+                        if (!RegExp(r'^[^@]+@[^@]+\.[^@]+')
+                            .hasMatch(value.trim())) {
+                          return 'Некорректный email';
+                        }
+                        return null;
+                      },
+                    )
+                        .animate()
+                        .fadeIn(delay: 400.ms, duration: 500.ms)
+                        .slideY(begin: 0.1, end: 0),
+                    const SizedBox(height: 20),
+
+                    // Auto-generated password field (read-only)
+                    _PasswordField(
+                      password: state.generatedPassword,
+                    )
+                        .animate()
+                        .fadeIn(delay: 500.ms, duration: 500.ms)
+                        .slideY(begin: 0.1, end: 0),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.auto_awesome,
+                          size: 14,
+                          color: AppColors.primary,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          'Пароль сгенерирован автоматически',
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: AppColors.primary,
+                                  ),
+                        ),
+                      ],
+                    ).animate().fadeIn(delay: 600.ms, duration: 400.ms),
+                    const SizedBox(height: 40),
+
+                    // Login button
+                    _LoginButton(
+                      isLoading: state.status == AuthStatus.loading,
+                      onPressed: _onLogin,
+                    )
+                        .animate()
+                        .fadeIn(delay: 700.ms, duration: 500.ms)
+                        .slideY(begin: 0.1, end: 0),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _BrandHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            color: AppColors.primary,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: const Icon(Icons.auto_stories, color: Colors.white, size: 30),
+        ),
+        const SizedBox(width: 14),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'AnimaLearn',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: AppColors.onSurface,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            Text(
+              'Учись через анимацию',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _PasswordField extends StatefulWidget {
+  const _PasswordField({required this.password});
+
+  final String? password;
+
+  @override
+  State<_PasswordField> createState() => _PasswordFieldState();
+}
+
+class _PasswordFieldState extends State<_PasswordField> {
+  bool _copied = false;
+
+  void _copy() {
+    if (widget.password == null) return;
+    Clipboard.setData(ClipboardData(text: widget.password!));
+    setState(() => _copied = true);
+    Future.delayed(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      readOnly: true,
+      initialValue: widget.password ?? '...',
+      obscureText: false,
+      style: const TextStyle(
+        fontFamily: 'monospace',
+        color: AppColors.secondary,
+        letterSpacing: 1.5,
+        fontWeight: FontWeight.w600,
+      ),
+      decoration: InputDecoration(
+        labelText: 'Пароль (автоматический)',
+        prefixIcon: const Icon(
+          Icons.lock_outlined,
+          color: AppColors.onSurfaceMuted,
+        ),
+        suffixIcon: IconButton(
+          onPressed: _copy,
+          icon: Icon(
+            _copied ? Icons.check : Icons.copy,
+            color: _copied ? AppColors.success : AppColors.onSurfaceMuted,
+            size: 20,
+          ),
+          tooltip: 'Скопировать пароль',
+        ),
+      ),
+    );
+  }
+}
+
+class _LoginButton extends StatelessWidget {
+  const _LoginButton({
+    required this.isLoading,
+    required this.onPressed,
+  });
+
+  final bool isLoading;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: isLoading ? null : onPressed,
+      child: isLoading
+          ? const SizedBox(
+              height: 22,
+              width: 22,
+              child: CircularProgressIndicator(
+                strokeWidth: 2.5,
+                color: Colors.white,
+              ),
+            )
+          : const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.rocket_launch_outlined, size: 20),
+                SizedBox(width: 10),
+                Text('Войти и начать'),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/features/player/bloc/player_bloc.dart
+++ b/lib/features/player/bloc/player_bloc.dart
@@ -1,0 +1,126 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../showcase/models/course.dart';
+import '../models/emotion_script_parser.dart';
+
+part 'player_event.dart';
+part 'player_state.dart';
+
+/// BLoC for the course player.
+///
+/// Controls:
+///   • Loading and parsing the emotion-script for each module.
+///   • Stepping through [ScriptSegment]s one by one.
+///   • Emitting the current emotion to drive the animation canvas.
+///   • Tracking module / course completion.
+class PlayerBloc extends Bloc<PlayerEvent, PlayerState> {
+  PlayerBloc() : super(const PlayerState()) {
+    on<PlayerLoadCourse>(_onLoadCourse);
+    on<PlayerTogglePlayback>(_onTogglePlayback);
+    on<PlayerAdvanceSegment>(_onAdvanceSegment);
+    on<PlayerGoToModule>(_onGoToModule);
+    on<PlayerCourseCompleted>(_onCourseCompleted);
+  }
+
+  Future<void> _onLoadCourse(
+    PlayerLoadCourse event,
+    Emitter<PlayerState> emit,
+  ) async {
+    emit(state.copyWith(status: PlayerStatus.loading));
+
+    // In production: fetch from Supabase. For demo use seed data.
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    final modules = Course.demoModules;
+    final segments = EmotionScriptParser.parse(modules.first.emotionScript);
+
+    emit(state.copyWith(
+      status: PlayerStatus.playing,
+      courseId: event.courseId,
+      modules: modules,
+      currentModuleIndex: 0,
+      currentSegmentIndex: 0,
+      segments: segments,
+      currentEmotion: _extractFirstEmotion(segments),
+    ));
+  }
+
+  void _onTogglePlayback(
+    PlayerTogglePlayback event,
+    Emitter<PlayerState> emit,
+  ) {
+    final newStatus = state.status == PlayerStatus.playing
+        ? PlayerStatus.paused
+        : PlayerStatus.playing;
+    emit(state.copyWith(status: newStatus));
+  }
+
+  void _onAdvanceSegment(
+    PlayerAdvanceSegment event,
+    Emitter<PlayerState> emit,
+  ) {
+    if (state.status == PlayerStatus.moduleComplete ||
+        state.status == PlayerStatus.courseComplete) {
+      return;
+    }
+
+    final nextIndex = state.currentSegmentIndex + 1;
+
+    if (nextIndex >= state.segments.length) {
+      // Module finished
+      if (state.isLastModule) {
+        emit(state.copyWith(status: PlayerStatus.courseComplete));
+      } else {
+        emit(state.copyWith(status: PlayerStatus.moduleComplete));
+      }
+      return;
+    }
+
+    final nextSegment = state.segments[nextIndex];
+    final emotion = nextSegment is EmotionSegment
+        ? nextSegment.emotion
+        : state.currentEmotion;
+
+    emit(state.copyWith(
+      currentSegmentIndex: nextIndex,
+      currentEmotion: emotion,
+      status: PlayerStatus.playing,
+    ));
+  }
+
+  void _onGoToModule(
+    PlayerGoToModule event,
+    Emitter<PlayerState> emit,
+  ) {
+    if (event.moduleIndex < 0 ||
+        event.moduleIndex >= state.modules.length) {
+      return;
+    }
+
+    final module = state.modules[event.moduleIndex];
+    final segments = EmotionScriptParser.parse(module.emotionScript);
+
+    emit(state.copyWith(
+      status: PlayerStatus.playing,
+      currentModuleIndex: event.moduleIndex,
+      currentSegmentIndex: 0,
+      segments: segments,
+      currentEmotion: _extractFirstEmotion(segments),
+    ));
+  }
+
+  void _onCourseCompleted(
+    PlayerCourseCompleted event,
+    Emitter<PlayerState> emit,
+  ) {
+    emit(state.copyWith(status: PlayerStatus.courseComplete));
+  }
+
+  String _extractFirstEmotion(List<ScriptSegment> segments) {
+    for (final seg in segments) {
+      if (seg is EmotionSegment) return seg.emotion;
+    }
+    return 'neutral';
+  }
+}

--- a/lib/features/player/bloc/player_event.dart
+++ b/lib/features/player/bloc/player_event.dart
@@ -1,0 +1,43 @@
+part of 'player_bloc.dart';
+
+abstract class PlayerEvent extends Equatable {
+  const PlayerEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Load the course by ID and prepare the first module.
+class PlayerLoadCourse extends PlayerEvent {
+  const PlayerLoadCourse({required this.courseId});
+
+  final String courseId;
+
+  @override
+  List<Object?> get props => [courseId];
+}
+
+/// User tapped play/pause.
+class PlayerTogglePlayback extends PlayerEvent {
+  const PlayerTogglePlayback();
+}
+
+/// Advance to the next segment in the current module.
+class PlayerAdvanceSegment extends PlayerEvent {
+  const PlayerAdvanceSegment();
+}
+
+/// Navigate to a specific module index.
+class PlayerGoToModule extends PlayerEvent {
+  const PlayerGoToModule({required this.moduleIndex});
+
+  final int moduleIndex;
+
+  @override
+  List<Object?> get props => [moduleIndex];
+}
+
+/// User finished the last module — ready to review.
+class PlayerCourseCompleted extends PlayerEvent {
+  const PlayerCourseCompleted();
+}

--- a/lib/features/player/bloc/player_state.dart
+++ b/lib/features/player/bloc/player_state.dart
@@ -1,0 +1,90 @@
+part of 'player_bloc.dart';
+
+enum PlayerStatus {
+  initial,
+  loading,
+  playing,
+  paused,
+  moduleComplete,
+  courseComplete,
+  failure,
+}
+
+class PlayerState extends Equatable {
+  const PlayerState({
+    this.status = PlayerStatus.initial,
+    this.courseId,
+    this.modules = const [],
+    this.currentModuleIndex = 0,
+    this.currentSegmentIndex = 0,
+    this.segments = const [],
+    this.currentEmotion = 'neutral',
+    this.errorMessage,
+  });
+
+  final PlayerStatus status;
+  final String? courseId;
+  final List<CourseModule> modules;
+
+  /// Index of the currently active module.
+  final int currentModuleIndex;
+
+  /// Index of the currently displayed segment within the module.
+  final int currentSegmentIndex;
+
+  /// Parsed segments for the current module.
+  final List<ScriptSegment> segments;
+
+  /// The most recently triggered emotion name (drives the animation).
+  final String currentEmotion;
+
+  final String? errorMessage;
+
+  CourseModule? get currentModule =>
+      modules.isNotEmpty ? modules[currentModuleIndex] : null;
+
+  ScriptSegment? get currentSegment =>
+      segments.isNotEmpty && currentSegmentIndex < segments.length
+          ? segments[currentSegmentIndex]
+          : null;
+
+  bool get isLastSegment => currentSegmentIndex >= segments.length - 1;
+  bool get isLastModule => currentModuleIndex >= modules.length - 1;
+
+  double get moduleProgress =>
+      segments.isEmpty ? 0 : (currentSegmentIndex + 1) / segments.length;
+
+  PlayerState copyWith({
+    PlayerStatus? status,
+    String? courseId,
+    List<CourseModule>? modules,
+    int? currentModuleIndex,
+    int? currentSegmentIndex,
+    List<ScriptSegment>? segments,
+    String? currentEmotion,
+    String? errorMessage,
+  }) {
+    return PlayerState(
+      status: status ?? this.status,
+      courseId: courseId ?? this.courseId,
+      modules: modules ?? this.modules,
+      currentModuleIndex: currentModuleIndex ?? this.currentModuleIndex,
+      currentSegmentIndex: currentSegmentIndex ?? this.currentSegmentIndex,
+      segments: segments ?? this.segments,
+      currentEmotion: currentEmotion ?? this.currentEmotion,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        courseId,
+        modules,
+        currentModuleIndex,
+        currentSegmentIndex,
+        segments,
+        currentEmotion,
+        errorMessage,
+      ];
+}

--- a/lib/features/player/models/emotion_script_parser.dart
+++ b/lib/features/player/models/emotion_script_parser.dart
@@ -1,0 +1,112 @@
+/// Parses the emotion-script format into a list of [ScriptSegment]s.
+///
+/// Emotion-script syntax:
+///   [EMOTION:name] — triggers a named emotion/animation state
+///   [CODE:lang] ... [/CODE] — a code block in the given language
+///   Plain text — narration text
+///
+/// Example:
+///   [EMOTION:excited] Hello! I'm PythonSnake.
+///   [CODE:python]
+///   print("Hello!")
+///   [/CODE]
+///   [EMOTION:happy] You just wrote Python!
+class EmotionScriptParser {
+  static final _emotionTag = RegExp(r'\[EMOTION:(\w+)\]');
+  static final _codeBlock = RegExp(r'\[CODE:(\w+)\]([\s\S]*?)\[/CODE\]');
+
+  /// Parses [script] into a flat list of segments.
+  static List<ScriptSegment> parse(String script) {
+    final segments = <ScriptSegment>[];
+    var remaining = script.trim();
+
+    while (remaining.isNotEmpty) {
+      // Try code block first (greedy)
+      final codeMatch = _codeBlock.firstMatch(remaining);
+      final emotionMatch = _emotionTag.firstMatch(remaining);
+
+      // Determine which comes first
+      final codeStart = codeMatch?.start ?? remaining.length;
+      final emotionStart = emotionMatch?.start ?? remaining.length;
+
+      if (codeStart == remaining.length && emotionStart == remaining.length) {
+        // Only plain text left
+        final text = remaining.trim();
+        if (text.isNotEmpty) {
+          segments.add(NarrationSegment(text: text));
+        }
+        break;
+      }
+
+      if (codeStart < emotionStart) {
+        // Text before code block
+        if (codeStart > 0) {
+          final pre = remaining.substring(0, codeStart).trim();
+          if (pre.isNotEmpty) segments.add(NarrationSegment(text: pre));
+        }
+        segments.add(CodeSegment(
+          language: codeMatch!.group(1)!,
+          code: codeMatch.group(2)!.trim(),
+        ));
+        remaining = remaining.substring(codeMatch.end);
+      } else {
+        // Text before emotion tag
+        if (emotionStart > 0) {
+          final pre = remaining.substring(0, emotionStart).trim();
+          if (pre.isNotEmpty) segments.add(NarrationSegment(text: pre));
+        }
+        final emotionName = emotionMatch!.group(1)!.toLowerCase();
+        segments.add(EmotionSegment(emotion: emotionName));
+        remaining = remaining.substring(emotionMatch.end);
+
+        // The text that directly follows the emotion tag (until next tag)
+        final nextMatch = RegExp(r'\[(?:EMOTION:|CODE:)')
+            .firstMatch(remaining);
+        final textEnd = nextMatch?.start ?? remaining.length;
+        final text = remaining.substring(0, textEnd).trim();
+        if (text.isNotEmpty) {
+          segments.add(NarrationSegment(text: text));
+        }
+        remaining = remaining.substring(textEnd);
+      }
+    }
+
+    return segments;
+  }
+}
+
+/// Base class for all script segments.
+sealed class ScriptSegment {
+  const ScriptSegment();
+}
+
+/// A named emotion/animation trigger.
+class EmotionSegment extends ScriptSegment {
+  const EmotionSegment({required this.emotion});
+
+  final String emotion; // e.g. "excited", "curious", "happy"
+
+  @override
+  String toString() => '[EmotionSegment: $emotion]';
+}
+
+/// Narration text to display as subtitle/card.
+class NarrationSegment extends ScriptSegment {
+  const NarrationSegment({required this.text});
+
+  final String text;
+
+  @override
+  String toString() => '[NarrationSegment: "$text"]';
+}
+
+/// A syntax-highlighted code block.
+class CodeSegment extends ScriptSegment {
+  const CodeSegment({required this.language, required this.code});
+
+  final String language;
+  final String code;
+
+  @override
+  String toString() => '[CodeSegment: $language "${code.split('\n').first}..."]';
+}

--- a/lib/features/player/screens/player_screen.dart
+++ b/lib/features/player/screens/player_screen.dart
@@ -1,0 +1,503 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../core/router/app_router.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../showcase/models/course.dart';
+import '../bloc/player_bloc.dart';
+import '../models/emotion_script_parser.dart';
+import '../widgets/emotion_avatar.dart';
+
+/// Course player screen.
+///
+/// Demo user journey step 3:
+///   • Loads the "Learn Python in 1 Hour" modules.
+///   • Displays the animated EmotionAvatar that reacts to [EmotionSegment]s.
+///   • Shows narration text and syntax-highlighted code blocks.
+///   • "Next" button advances through script segments.
+///   • On last module completion → navigates to [ReviewScreen].
+class PlayerScreen extends StatelessWidget {
+  const PlayerScreen({super.key, required this.courseId});
+
+  final String courseId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => PlayerBloc()..add(PlayerLoadCourse(courseId: courseId)),
+      child: _PlayerView(courseId: courseId),
+    );
+  }
+}
+
+class _PlayerView extends StatelessWidget {
+  const _PlayerView({required this.courseId});
+
+  final String courseId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<PlayerBloc, PlayerState>(
+      listener: (context, state) {
+        if (state.status == PlayerStatus.courseComplete) {
+          Navigator.of(context).pushReplacementNamed(
+            AppRoutes.review,
+            arguments: courseId,
+          );
+        }
+      },
+      builder: (context, state) {
+        return Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: _PlayerAppBar(state: state),
+          body: switch (state.status) {
+            PlayerStatus.initial || PlayerStatus.loading => const _LoadingView(),
+            PlayerStatus.failure => _ErrorView(
+                message: state.errorMessage ?? 'Ошибка загрузки курса',
+              ),
+            _ => _ActivePlayer(state: state),
+          },
+        );
+      },
+    );
+  }
+}
+
+class _PlayerAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _PlayerAppBar({required this.state});
+
+  final PlayerState state;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 4);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(
+        state.currentModule?.title ?? 'Загрузка...',
+        style: const TextStyle(fontSize: 16),
+      ),
+      bottom: state.modules.isNotEmpty
+          ? PreferredSize(
+              preferredSize: const Size.fromHeight(4),
+              child: LinearProgressIndicator(
+                value: state.moduleProgress,
+                backgroundColor: AppColors.surfaceVariant,
+                valueColor:
+                    const AlwaysStoppedAnimation<Color>(AppColors.primary),
+                minHeight: 4,
+              ),
+            )
+          : null,
+      actions: [
+        // Module counter
+        if (state.modules.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: Center(
+              child: Text(
+                '${state.currentModuleIndex + 1}/${state.modules.length}',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: AppColors.primary),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ActivePlayer extends StatelessWidget {
+  const _ActivePlayer({required this.state});
+
+  final PlayerState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final segment = state.currentSegment;
+
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Animation canvas — EmotionAvatar
+                EmotionAvatar(emotion: state.currentEmotion),
+                const SizedBox(height: 32),
+
+                // Current segment content
+                if (segment != null) _SegmentDisplay(segment: segment),
+
+                const SizedBox(height: 24),
+
+                // Module progress indicator
+                _ModuleList(state: state),
+              ],
+            ),
+          ),
+        ),
+
+        // Bottom controls
+        _PlayerControls(state: state),
+      ],
+    );
+  }
+}
+
+class _SegmentDisplay extends StatelessWidget {
+  const _SegmentDisplay({required this.segment});
+
+  final ScriptSegment segment;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 400),
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(0, 0.05),
+            end: Offset.zero,
+          ).animate(animation),
+          child: child,
+        ),
+      ),
+      child: switch (segment) {
+        EmotionSegment() => const SizedBox.shrink(),
+        NarrationSegment(:final text) => _NarrationCard(text: text),
+        CodeSegment(:final language, :final code) =>
+          _CodeCard(language: language, code: code),
+      },
+    );
+  }
+}
+
+class _NarrationCard extends StatelessWidget {
+  const _NarrationCard({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: ValueKey(text),
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.primary.withOpacity(0.2),
+          width: 1,
+        ),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              height: 1.6,
+              fontSize: 17,
+            ),
+        textAlign: TextAlign.center,
+      ),
+    ).animate().fadeIn(duration: 400.ms).slideY(begin: 0.05, end: 0);
+  }
+}
+
+class _CodeCard extends StatelessWidget {
+  const _CodeCard({required this.language, required this.code});
+
+  final String language;
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: ValueKey(code),
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E1E2E),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.secondary.withOpacity(0.3),
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            decoration: BoxDecoration(
+              color: AppColors.surfaceVariant.withOpacity(0.5),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(16)),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Color(0xFFFF5F57),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Color(0xFFFFBD2E),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Color(0xFF28CA41),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  language,
+                  style: const TextStyle(
+                    color: AppColors.onSurfaceMuted,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Code body
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: SelectableText(
+              code,
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 14,
+                color: Color(0xFFCDD6F4),
+                height: 1.6,
+                letterSpacing: 0.3,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ).animate().fadeIn(duration: 400.ms).slideY(begin: 0.05, end: 0);
+  }
+}
+
+class _ModuleList extends StatelessWidget {
+  const _ModuleList({required this.state});
+
+  final PlayerState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        Text(
+          'Модули курса',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: AppColors.onSurfaceMuted,
+              ),
+        ),
+        const SizedBox(height: 8),
+        ...state.modules.asMap().entries.map((entry) {
+          final i = entry.key;
+          final module = entry.value;
+          final isActive = i == state.currentModuleIndex;
+          final isDone = i < state.currentModuleIndex;
+
+          return GestureDetector(
+            onTap: () => context
+                .read<PlayerBloc>()
+                .add(PlayerGoToModule(moduleIndex: i)),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              margin: const EdgeInsets.only(bottom: 8),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+              decoration: BoxDecoration(
+                color: isActive
+                    ? AppColors.primary.withOpacity(0.15)
+                    : AppColors.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: isActive
+                      ? AppColors.primary.withOpacity(0.5)
+                      : Colors.transparent,
+                  width: 1,
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    isDone
+                        ? Icons.check_circle
+                        : isActive
+                            ? Icons.play_circle_filled
+                            : Icons.radio_button_unchecked,
+                    size: 18,
+                    color: isDone
+                        ? AppColors.success
+                        : isActive
+                            ? AppColors.primary
+                            : AppColors.onSurfaceMuted,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      '${i + 1}. ${module.title}',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: isActive
+                                ? AppColors.onSurface
+                                : AppColors.onSurfaceMuted,
+                            fontWeight: isActive
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                    ),
+                  ),
+                  Text(
+                    '${module.durationMinutes} мин',
+                    style: Theme.of(context).textTheme.labelSmall,
+                  ),
+                ],
+              ),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+}
+
+class _PlayerControls extends StatelessWidget {
+  const _PlayerControls({required this.state});
+
+  final PlayerState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = context.read<PlayerBloc>();
+    final isModuleComplete = state.status == PlayerStatus.moduleComplete;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: const Border(
+          top: BorderSide(color: AppColors.surfaceVariant, width: 1),
+        ),
+      ),
+      child: Row(
+        children: [
+          // Play/Pause
+          IconButton(
+            onPressed: () => bloc.add(const PlayerTogglePlayback()),
+            icon: Icon(
+              state.status == PlayerStatus.playing
+                  ? Icons.pause_circle_filled
+                  : Icons.play_circle_filled,
+              size: 44,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(width: 16),
+
+          // Next segment / Next module / Finish
+          Expanded(
+            child: ElevatedButton(
+              onPressed: () {
+                if (isModuleComplete) {
+                  final nextIndex = state.currentModuleIndex + 1;
+                  if (nextIndex < state.modules.length) {
+                    bloc.add(PlayerGoToModule(moduleIndex: nextIndex));
+                  } else {
+                    bloc.add(const PlayerCourseCompleted());
+                  }
+                } else {
+                  bloc.add(const PlayerAdvanceSegment());
+                }
+              },
+              child: Text(
+                isModuleComplete
+                    ? (state.isLastModule
+                        ? '🎉 Завершить курс'
+                        : '➡ Следующий модуль')
+                    : (state.isLastSegment
+                        ? '✅ Завершить урок'
+                        : 'Далее →'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadingView extends StatelessWidget {
+  const _LoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(color: AppColors.primary),
+          SizedBox(height: 20),
+          Text(
+            'Загружаем курс...',
+            style: TextStyle(color: AppColors.onSurfaceMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 56, color: AppColors.error),
+          const SizedBox(height: 16),
+          Text(message, style: Theme.of(context).textTheme.bodyLarge),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Назад'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/emotion_avatar.dart
+++ b/lib/features/player/widgets/emotion_avatar.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../../../core/theme/app_theme.dart';
+
+/// Displays a 2D animated avatar that reacts to emotion states.
+///
+/// In production this widget would drive a Rive StateMachine with the named
+/// emotion input. For the demo we use emoji + colour-coded containers that
+/// animate smoothly on emotion change.
+///
+/// Supported emotions (map to Rive state machine inputs in production):
+///   excited, curious, happy, thinking, explaining, energetic,
+///   celebrating, wise, proud, neutral
+class EmotionAvatar extends StatelessWidget {
+  const EmotionAvatar({
+    super.key,
+    required this.emotion,
+    this.size = 180,
+  });
+
+  final String emotion;
+  final double size;
+
+  static const _emotionData = <String, _EmotionData>{
+    'excited': _EmotionData(emoji: '🤩', primary: Color(0xFFF59E0B), label: 'Восторг'),
+    'curious': _EmotionData(emoji: '🤔', primary: Color(0xFF6366F1), label: 'Любопытство'),
+    'happy': _EmotionData(emoji: '😊', primary: Color(0xFF10B981), label: 'Радость'),
+    'thinking': _EmotionData(emoji: '💭', primary: Color(0xFF8B5CF6), label: 'Размышление'),
+    'explaining': _EmotionData(emoji: '📖', primary: Color(0xFF3B82F6), label: 'Объяснение'),
+    'energetic': _EmotionData(emoji: '⚡', primary: Color(0xFFEF4444), label: 'Энергия'),
+    'celebrating': _EmotionData(emoji: '🎉', primary: Color(0xFFF59E0B), label: 'Праздник'),
+    'wise': _EmotionData(emoji: '🦉', primary: Color(0xFF0D9488), label: 'Мудрость'),
+    'proud': _EmotionData(emoji: '💪', primary: Color(0xFF10B981), label: 'Гордость'),
+    'neutral': _EmotionData(emoji: '🐍', primary: AppColors.primary, label: 'Пайтоша'),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final data = _emotionData[emotion] ?? _emotionData['neutral']!;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 500),
+      transitionBuilder: (child, animation) => ScaleTransition(
+        scale: animation,
+        child: FadeTransition(opacity: animation, child: child),
+      ),
+      child: _AvatarBody(key: ValueKey(emotion), data: data, size: size),
+    );
+  }
+}
+
+class _AvatarBody extends StatelessWidget {
+  const _AvatarBody({
+    super.key,
+    required this.data,
+    required this.size,
+  });
+
+  final _EmotionData data;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: RadialGradient(
+          colors: [
+            data.primary.withOpacity(0.3),
+            data.primary.withOpacity(0.05),
+          ],
+        ),
+        border: Border.all(
+          color: data.primary.withOpacity(0.4),
+          width: 2,
+        ),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Pulsing ring
+          Container(
+            width: size * 0.85,
+            height: size * 0.85,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: data.primary.withOpacity(0.2),
+                width: 1.5,
+              ),
+            ),
+          )
+              .animate(onPlay: (c) => c.repeat())
+              .scale(
+                begin: const Offset(0.95, 0.95),
+                end: const Offset(1.05, 1.05),
+                duration: 1200.ms,
+                curve: Curves.easeInOut,
+              )
+              .then()
+              .scale(
+                begin: const Offset(1.05, 1.05),
+                end: const Offset(0.95, 0.95),
+                duration: 1200.ms,
+                curve: Curves.easeInOut,
+              ),
+
+          // Emoji character
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                data.emoji,
+                style: TextStyle(fontSize: size * 0.38),
+              )
+                  .animate(onPlay: (c) => c.repeat(reverse: true))
+                  .moveY(
+                    begin: 0,
+                    end: -8,
+                    duration: 1000.ms,
+                    curve: Curves.easeInOut,
+                  ),
+              const SizedBox(height: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: data.primary.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  data.label,
+                  style: TextStyle(
+                    color: data.primary,
+                    fontSize: size * 0.08,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmotionData {
+  const _EmotionData({
+    required this.emoji,
+    required this.primary,
+    required this.label,
+  });
+
+  final String emoji;
+  final Color primary;
+  final String label;
+}

--- a/lib/features/review/bloc/review_bloc.dart
+++ b/lib/features/review/bloc/review_bloc.dart
@@ -1,0 +1,65 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:logger/logger.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'review_event.dart';
+part 'review_state.dart';
+
+final _log = Logger(printer: PrettyPrinter(methodCount: 0));
+
+/// BLoC for the end-of-course review screen.
+///
+/// Submits the rating + text to Supabase via the `reviews` Edge Function.
+class ReviewBloc extends Bloc<ReviewEvent, ReviewState> {
+  ReviewBloc() : super(const ReviewState()) {
+    on<ReviewRatingChanged>(_onRatingChanged);
+    on<ReviewTextChanged>(_onTextChanged);
+    on<ReviewSubmitted>(_onSubmitted);
+  }
+
+  void _onRatingChanged(
+    ReviewRatingChanged event,
+    Emitter<ReviewState> emit,
+  ) {
+    emit(state.copyWith(rating: event.rating));
+  }
+
+  void _onTextChanged(
+    ReviewTextChanged event,
+    Emitter<ReviewState> emit,
+  ) {
+    emit(state.copyWith(reviewText: event.text));
+  }
+
+  Future<void> _onSubmitted(
+    ReviewSubmitted event,
+    Emitter<ReviewState> emit,
+  ) async {
+    if (!state.canSubmit) return;
+
+    emit(state.copyWith(status: ReviewStatus.submitting));
+
+    try {
+      // Call the Supabase Edge Function `reviews`.
+      // In demo mode this is a best-effort call — failures are silently caught.
+      await Supabase.instance.client.functions.invoke(
+        'reviews',
+        body: {
+          'course_id': event.courseId,
+          'rating': state.rating,
+          'text': state.reviewText.trim(),
+        },
+      );
+      _log.i(
+        'Review submitted — course: ${event.courseId}, '
+        'rating: ${state.rating}',
+      );
+    } catch (e) {
+      // Log but don't block the user in demo mode
+      _log.w('Review submission failed (demo mode): $e');
+    }
+
+    emit(state.copyWith(status: ReviewStatus.success));
+  }
+}

--- a/lib/features/review/bloc/review_event.dart
+++ b/lib/features/review/bloc/review_event.dart
@@ -1,0 +1,35 @@
+part of 'review_bloc.dart';
+
+abstract class ReviewEvent extends Equatable {
+  const ReviewEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ReviewRatingChanged extends ReviewEvent {
+  const ReviewRatingChanged({required this.rating});
+
+  final double rating;
+
+  @override
+  List<Object?> get props => [rating];
+}
+
+class ReviewTextChanged extends ReviewEvent {
+  const ReviewTextChanged({required this.text});
+
+  final String text;
+
+  @override
+  List<Object?> get props => [text];
+}
+
+class ReviewSubmitted extends ReviewEvent {
+  const ReviewSubmitted({required this.courseId});
+
+  final String courseId;
+
+  @override
+  List<Object?> get props => [courseId];
+}

--- a/lib/features/review/bloc/review_state.dart
+++ b/lib/features/review/bloc/review_state.dart
@@ -1,0 +1,36 @@
+part of 'review_bloc.dart';
+
+enum ReviewStatus { initial, submitting, success, failure }
+
+class ReviewState extends Equatable {
+  const ReviewState({
+    this.status = ReviewStatus.initial,
+    this.rating = 0.0,
+    this.reviewText = '',
+    this.errorMessage,
+  });
+
+  final ReviewStatus status;
+  final double rating;
+  final String reviewText;
+  final String? errorMessage;
+
+  bool get canSubmit => rating > 0;
+
+  ReviewState copyWith({
+    ReviewStatus? status,
+    double? rating,
+    String? reviewText,
+    String? errorMessage,
+  }) {
+    return ReviewState(
+      status: status ?? this.status,
+      rating: rating ?? this.rating,
+      reviewText: reviewText ?? this.reviewText,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, rating, reviewText, errorMessage];
+}

--- a/lib/features/review/screens/review_screen.dart
+++ b/lib/features/review/screens/review_screen.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+
+import '../../../core/router/app_router.dart';
+import '../../../core/theme/app_theme.dart';
+import '../bloc/review_bloc.dart';
+
+/// End-of-course review screen.
+///
+/// Demo user journey step 4:
+///   • Star rating (1-5) using [RatingBar].
+///   • Optional text review field.
+///   • "Submit" button → saves via [ReviewBloc] to Supabase Edge Function.
+///   • After success → back to [ShowcaseScreen].
+class ReviewScreen extends StatelessWidget {
+  const ReviewScreen({super.key, required this.courseId});
+
+  final String courseId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => ReviewBloc(),
+      child: _ReviewView(courseId: courseId),
+    );
+  }
+}
+
+class _ReviewView extends StatefulWidget {
+  const _ReviewView({required this.courseId});
+
+  final String courseId;
+
+  @override
+  State<_ReviewView> createState() => _ReviewViewState();
+}
+
+class _ReviewViewState extends State<_ReviewView> {
+  final _reviewController = TextEditingController();
+
+  @override
+  void dispose() {
+    _reviewController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Оценить курс'),
+        automaticallyImplyLeading: false,
+      ),
+      body: BlocConsumer<ReviewBloc, ReviewState>(
+        listener: (context, state) {
+          if (state.status == ReviewStatus.success) {
+            // Show success snackbar then go back to showcase
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Отзыв отправлен! Спасибо 🙏'),
+                backgroundColor: AppColors.success,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+            Future.delayed(const Duration(seconds: 1), () {
+              if (context.mounted) {
+                Navigator.of(context).pushNamedAndRemoveUntil(
+                  AppRoutes.showcase,
+                  (route) => false,
+                );
+              }
+            });
+          }
+        },
+        builder: (context, state) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(28),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const SizedBox(height: 16),
+
+                // Celebration header
+                _CompletionHeader()
+                    .animate()
+                    .fadeIn(duration: 600.ms)
+                    .scale(
+                        begin: const Offset(0.8, 0.8),
+                        end: const Offset(1, 1)),
+                const SizedBox(height: 40),
+
+                // Rating section
+                _RatingSection(currentRating: state.rating)
+                    .animate()
+                    .fadeIn(delay: 300.ms, duration: 500.ms)
+                    .slideY(begin: 0.1, end: 0),
+                const SizedBox(height: 32),
+
+                // Review text
+                _ReviewTextField(controller: _reviewController)
+                    .animate()
+                    .fadeIn(delay: 500.ms, duration: 500.ms)
+                    .slideY(begin: 0.1, end: 0),
+                const SizedBox(height: 32),
+
+                // Submit button
+                _SubmitButton(
+                  state: state,
+                  courseId: widget.courseId,
+                  reviewController: _reviewController,
+                )
+                    .animate()
+                    .fadeIn(delay: 700.ms, duration: 500.ms)
+                    .slideY(begin: 0.1, end: 0),
+                const SizedBox(height: 16),
+
+                // Skip link
+                TextButton(
+                  onPressed: () => Navigator.of(context)
+                      .pushNamedAndRemoveUntil(
+                          AppRoutes.showcase, (route) => false),
+                  child: const Text(
+                    'Пропустить',
+                    style: TextStyle(color: AppColors.onSurfaceMuted),
+                  ),
+                ).animate().fadeIn(delay: 800.ms, duration: 400.ms),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CompletionHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 100,
+          height: 100,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              colors: [
+                AppColors.primary,
+                AppColors.secondary.withOpacity(0.8),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: const Center(
+            child: Text('🎓', style: TextStyle(fontSize: 50)),
+          ),
+        )
+            .animate(onPlay: (c) => c.repeat(reverse: true))
+            .scale(
+              begin: const Offset(0.95, 0.95),
+              end: const Offset(1.05, 1.05),
+              duration: 1200.ms,
+              curve: Curves.easeInOut,
+            ),
+        const SizedBox(height: 20),
+        Text(
+          'Курс пройден!',
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Вы прошли "Выучи Python за 1 час".\nРасскажите, как это было!',
+          style: Theme.of(context).textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _RatingSection extends StatelessWidget {
+  const _RatingSection({required this.currentRating});
+
+  final double currentRating;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          'Ваша оценка курса',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 16),
+        RatingBar.builder(
+          initialRating: currentRating,
+          minRating: 1,
+          maxRating: 5,
+          allowHalfRating: true,
+          itemCount: 5,
+          itemSize: 48,
+          glow: true,
+          glowColor: AppColors.starColor.withOpacity(0.3),
+          unratedColor: AppColors.surfaceVariant,
+          itemBuilder: (context, _) => const Icon(
+            Icons.star_rounded,
+            color: AppColors.starColor,
+          ),
+          onRatingUpdate: (rating) => context
+              .read<ReviewBloc>()
+              .add(ReviewRatingChanged(rating: rating)),
+        ),
+        const SizedBox(height: 12),
+        if (currentRating > 0)
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: Text(
+              key: ValueKey(currentRating),
+              _ratingLabel(currentRating),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: AppColors.starColor,
+                    fontWeight: FontWeight.w500,
+                  ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _ratingLabel(double rating) {
+    if (rating >= 4.5) return '⭐ Отлично!';
+    if (rating >= 3.5) return '👍 Хорошо';
+    if (rating >= 2.5) return '😐 Нормально';
+    if (rating >= 1.5) return '👎 Плохо';
+    return '😞 Очень плохо';
+  }
+}
+
+class _ReviewTextField extends StatelessWidget {
+  const _ReviewTextField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Напишите отзыв (необязательно)',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: controller,
+          maxLines: 4,
+          maxLength: 500,
+          onChanged: (text) => context
+              .read<ReviewBloc>()
+              .add(ReviewTextChanged(text: text)),
+          decoration: InputDecoration(
+            hintText:
+                'Что вам понравилось? Что можно улучшить?',
+            hintStyle:
+                const TextStyle(color: AppColors.onSurfaceMuted, fontSize: 14),
+            counterStyle:
+                const TextStyle(color: AppColors.onSurfaceMuted, fontSize: 11),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SubmitButton extends StatelessWidget {
+  const _SubmitButton({
+    required this.state,
+    required this.courseId,
+    required this.reviewController,
+  });
+
+  final ReviewState state;
+  final String courseId;
+  final TextEditingController reviewController;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoading = state.status == ReviewStatus.submitting;
+
+    return ElevatedButton(
+      onPressed: !state.canSubmit || isLoading
+          ? null
+          : () => context
+              .read<ReviewBloc>()
+              .add(ReviewSubmitted(courseId: courseId)),
+      style: ElevatedButton.styleFrom(
+        backgroundColor:
+            state.canSubmit ? AppColors.primary : AppColors.surfaceVariant,
+      ),
+      child: isLoading
+          ? const SizedBox(
+              height: 22,
+              width: 22,
+              child: CircularProgressIndicator(
+                  strokeWidth: 2.5, color: Colors.white),
+            )
+          : const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.send_rounded, size: 18),
+                SizedBox(width: 10),
+                Text('Отправить отзыв'),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/features/showcase/bloc/showcase_bloc.dart
+++ b/lib/features/showcase/bloc/showcase_bloc.dart
@@ -1,0 +1,40 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../models/course.dart';
+
+part 'showcase_event.dart';
+part 'showcase_state.dart';
+
+/// BLoC for the Showcase (course listing) screen.
+///
+/// In production this would fetch courses from the Supabase `courses` Edge
+/// Function. For the demo we load the seed data immediately.
+class ShowcaseBloc extends Bloc<ShowcaseEvent, ShowcaseState> {
+  ShowcaseBloc() : super(const ShowcaseState()) {
+    on<ShowcaseLoadCourses>(_onLoadCourses);
+    on<ShowcaseCourseSelected>(_onCourseSelected);
+  }
+
+  Future<void> _onLoadCourses(
+    ShowcaseLoadCourses event,
+    Emitter<ShowcaseState> emit,
+  ) async {
+    emit(state.copyWith(status: ShowcaseStatus.loading));
+
+    // Simulate a brief network delay for visual feedback
+    await Future<void>.delayed(const Duration(milliseconds: 600));
+
+    emit(state.copyWith(
+      status: ShowcaseStatus.success,
+      courses: [Course.demoCourse],
+    ));
+  }
+
+  void _onCourseSelected(
+    ShowcaseCourseSelected event,
+    Emitter<ShowcaseState> emit,
+  ) {
+    emit(state.copyWith(selectedCourseId: event.courseId));
+  }
+}

--- a/lib/features/showcase/bloc/showcase_event.dart
+++ b/lib/features/showcase/bloc/showcase_event.dart
@@ -1,0 +1,21 @@
+part of 'showcase_bloc.dart';
+
+abstract class ShowcaseEvent extends Equatable {
+  const ShowcaseEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ShowcaseLoadCourses extends ShowcaseEvent {
+  const ShowcaseLoadCourses();
+}
+
+class ShowcaseCourseSelected extends ShowcaseEvent {
+  const ShowcaseCourseSelected({required this.courseId});
+
+  final String courseId;
+
+  @override
+  List<Object?> get props => [courseId];
+}

--- a/lib/features/showcase/bloc/showcase_state.dart
+++ b/lib/features/showcase/bloc/showcase_state.dart
@@ -1,0 +1,34 @@
+part of 'showcase_bloc.dart';
+
+enum ShowcaseStatus { initial, loading, success, failure }
+
+class ShowcaseState extends Equatable {
+  const ShowcaseState({
+    this.status = ShowcaseStatus.initial,
+    this.courses = const [],
+    this.selectedCourseId,
+    this.errorMessage,
+  });
+
+  final ShowcaseStatus status;
+  final List<Course> courses;
+  final String? selectedCourseId;
+  final String? errorMessage;
+
+  ShowcaseState copyWith({
+    ShowcaseStatus? status,
+    List<Course>? courses,
+    String? selectedCourseId,
+    String? errorMessage,
+  }) {
+    return ShowcaseState(
+      status: status ?? this.status,
+      courses: courses ?? this.courses,
+      selectedCourseId: selectedCourseId ?? this.selectedCourseId,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, courses, selectedCourseId, errorMessage];
+}

--- a/lib/features/showcase/models/course.dart
+++ b/lib/features/showcase/models/course.dart
@@ -1,0 +1,176 @@
+import 'package:equatable/equatable.dart';
+
+class Course extends Equatable {
+  const Course({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.author,
+    required this.rating,
+    required this.totalRatings,
+    required this.durationMinutes,
+    required this.moduleCount,
+    required this.level,
+    required this.tags,
+    this.thumbnailUrl,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final String author;
+  final double rating;
+  final int totalRatings;
+  final int durationMinutes;
+  final int moduleCount;
+  final String level; // 'Начинающий' | 'Средний' | 'Продвинутый'
+  final List<String> tags;
+  final String? thumbnailUrl;
+
+  /// Demo seed data — the course from the issue requirements.
+  static const demoCourse = Course(
+    id: 'python-1h',
+    title: 'Выучи Python за 1 час',
+    description:
+        'Быстрый и увлекательный курс по Python с эмоциональными анимациями. '
+        'Переменные, циклы, функции — всё через 2D-персонажей, которые объясняют сложное просто.',
+    author: 'AnimaLearn Team',
+    rating: 4.8,
+    totalRatings: 1240,
+    durationMinutes: 60,
+    moduleCount: 6,
+    level: 'Начинающий',
+    tags: ['Python', 'Программирование', 'Анимация', '2D'],
+  );
+
+  /// What-you-will-learn checklist items for the demo course.
+  static const demoLearningOutcomes = [
+    'Установить Python и настроить среду',
+    'Понять переменные и типы данных',
+    'Использовать циклы for и while',
+    'Писать собственные функции',
+    'Работать со списками и словарями',
+    'Создать первую мини-программу',
+  ];
+
+  /// Course modules for the demo course.
+  static const demoModules = [
+    CourseModule(
+      id: 'python-1h-m1',
+      title: 'Привет, Python!',
+      durationMinutes: 8,
+      emotionScript: '''
+[EMOTION:excited] Привет! Я Пайтоша — твой проводник в мир Python.
+[EMOTION:curious] Python — это язык, который читается почти как обычный текст.
+[EMOTION:happy] Давай напишем твою первую программу!
+[CODE:python]
+print("Привет, мир!")
+[/CODE]
+[EMOTION:proud] Отлично! Ты только что написал первую программу на Python!
+''',
+    ),
+    CourseModule(
+      id: 'python-1h-m2',
+      title: 'Переменные и типы',
+      durationMinutes: 12,
+      emotionScript: '''
+[EMOTION:thinking] Переменная — это коробочка для хранения данных.
+[EMOTION:explaining] В Python есть несколько основных типов данных.
+[CODE:python]
+name = "Алиса"      # строка (str)
+age = 25            # целое число (int)
+height = 1.68       # дробное число (float)
+is_student = True   # булево значение (bool)
+[/CODE]
+[EMOTION:excited] Python сам определяет тип! Это называется динамическая типизация.
+''',
+    ),
+    CourseModule(
+      id: 'python-1h-m3',
+      title: 'Циклы',
+      durationMinutes: 10,
+      emotionScript: '''
+[EMOTION:energetic] Циклы позволяют повторять действия много раз!
+[CODE:python]
+for i in range(5):
+    print(f"Шаг {i + 1}")
+[/CODE]
+[EMOTION:celebrating] Цикл for прошёл 5 раз автоматически. Магия!
+''',
+    ),
+    CourseModule(
+      id: 'python-1h-m4',
+      title: 'Функции',
+      durationMinutes: 12,
+      emotionScript: '''
+[EMOTION:wise] Функция — это именованный блок кода, который можно вызывать снова и снова.
+[CODE:python]
+def greet(name: str) -> str:
+    return f"Привет, {name}!"
+
+print(greet("Алиса"))
+print(greet("Боб"))
+[/CODE]
+[EMOTION:proud] Ты только что создал переиспользуемый код. Это важный навык!
+''',
+    ),
+    CourseModule(
+      id: 'python-1h-m5',
+      title: 'Списки и словари',
+      durationMinutes: 10,
+      emotionScript: '''
+[EMOTION:curious] Списки хранят много элементов. Словари — пары ключ-значение.
+[CODE:python]
+fruits = ["яблоко", "банан", "вишня"]
+person = {"имя": "Алиса", "возраст": 25}
+
+print(fruits[0])        # яблоко
+print(person["имя"])    # Алиса
+[/CODE]
+[EMOTION:happy] Эти структуры данных ты будешь использовать каждый день!
+''',
+    ),
+    CourseModule(
+      id: 'python-1h-m6',
+      title: 'Мини-проект: Калькулятор',
+      durationMinutes: 8,
+      emotionScript: '''
+[EMOTION:excited] Финальный урок! Создадим простой калькулятор.
+[CODE:python]
+def calculator(a: float, b: float, op: str) -> float:
+    if op == "+": return a + b
+    if op == "-": return a - b
+    if op == "*": return a * b
+    if op == "/" and b != 0: return a / b
+    raise ValueError(f"Неизвестная операция: {op}")
+
+result = calculator(10, 3, "+")
+print(f"10 + 3 = {result}")
+[/CODE]
+[EMOTION:celebrating] Поздравляю! Ты прошёл курс и написал свой первый проект!
+''',
+    ),
+  ];
+
+  @override
+  List<Object?> get props => [id, title, author, rating];
+}
+
+class CourseModule extends Equatable {
+  const CourseModule({
+    required this.id,
+    required this.title,
+    required this.durationMinutes,
+    required this.emotionScript,
+  });
+
+  final String id;
+  final String title;
+  final int durationMinutes;
+
+  /// Emotion-script text used to drive the animation + narration.
+  final String emotionScript;
+
+  @override
+  List<Object?> get props => [id, title];
+}

--- a/lib/features/showcase/screens/showcase_screen.dart
+++ b/lib/features/showcase/screens/showcase_screen.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shimmer/shimmer.dart';
+
+import '../../../core/router/app_router.dart';
+import '../../../core/theme/app_theme.dart';
+import '../bloc/showcase_bloc.dart';
+import '../widgets/course_card.dart';
+
+/// Showcase (course catalog) screen.
+///
+/// Demo user journey step 2:
+///   • Displays a course card for "Выучи Python за 1 час".
+///   • Tapping the card navigates to [PlayerScreen].
+class ShowcaseScreen extends StatelessWidget {
+  const ShowcaseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Витрина курсов'),
+        leading: const Padding(
+          padding: EdgeInsets.all(8),
+          child: Icon(Icons.auto_stories, color: AppColors.primary, size: 28),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search_outlined),
+            onPressed: () {},
+            tooltip: 'Поиск',
+          ),
+        ],
+      ),
+      body: BlocBuilder<ShowcaseBloc, ShowcaseState>(
+        builder: (context, state) {
+          return switch (state.status) {
+            ShowcaseStatus.initial ||
+            ShowcaseStatus.loading =>
+              const _LoadingContent(),
+            ShowcaseStatus.failure => _ErrorContent(
+                message: state.errorMessage ?? 'Ошибка загрузки курсов',
+              ),
+            ShowcaseStatus.success => _CourseList(state: state),
+          };
+        },
+      ),
+    );
+  }
+}
+
+class _CourseList extends StatelessWidget {
+  const _CourseList({required this.state});
+
+  final ShowcaseState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        // Hero banner
+        SliverToBoxAdapter(
+          child: _HeroBanner().animate().fadeIn(duration: 600.ms),
+        ),
+
+        // Section header
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 12),
+          sliver: SliverToBoxAdapter(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Популярные курсы',
+                  style: Theme.of(context).textTheme.titleLarge,
+                )
+                    .animate()
+                    .fadeIn(delay: 200.ms, duration: 400.ms)
+                    .slideX(begin: -0.1, end: 0),
+                Text(
+                  '${state.courses.length} курсов',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ).animate().fadeIn(delay: 300.ms, duration: 400.ms),
+              ],
+            ),
+          ),
+        ),
+
+        // Course cards
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          sliver: SliverList.separated(
+            itemCount: state.courses.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 16),
+            itemBuilder: (context, index) {
+              final course = state.courses[index];
+              return CourseCard(
+                course: course,
+                onTap: () => Navigator.of(context).pushNamed(
+                  AppRoutes.player,
+                  arguments: course.id,
+                ),
+              );
+            },
+          ),
+        ),
+
+        const SliverPadding(padding: EdgeInsets.only(bottom: 32)),
+      ],
+    );
+  }
+}
+
+class _HeroBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+      height: 140,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF4F46E5), Color(0xFF7C3AED)],
+        ),
+      ),
+      child: Stack(
+        children: [
+          // Decorative circles
+          Positioned(
+            right: -10,
+            top: -20,
+            child: Container(
+              width: 110,
+              height: 110,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.08),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 30,
+            bottom: -30,
+            child: Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.06),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '🎯  Учись через анимацию',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Colors.white70,
+                        fontSize: 12,
+                        letterSpacing: 0.5,
+                      ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Emotion-scripts делают\nобучение незабываемым',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: const Text(
+                    'Смотреть всё →',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadingContent extends StatelessWidget {
+  const _LoadingContent();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.all(20),
+      itemCount: 3,
+      separatorBuilder: (_, __) => const SizedBox(height: 16),
+      itemBuilder: (_, __) => Shimmer.fromColors(
+        baseColor: AppColors.surface,
+        highlightColor: AppColors.surfaceVariant,
+        child: Container(
+          height: 360,
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(20),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorContent extends StatelessWidget {
+  const _ErrorContent({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 56, color: AppColors.error),
+          const SizedBox(height: 16),
+          Text(message, style: Theme.of(context).textTheme.bodyLarge),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => context
+                .read<ShowcaseBloc>()
+                .add(const ShowcaseLoadCourses()),
+            child: const Text('Повторить'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/showcase/widgets/course_card.dart
+++ b/lib/features/showcase/widgets/course_card.dart
@@ -1,0 +1,331 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../models/course.dart';
+
+/// A rich card displaying course meta-data.
+///
+/// Tapping the card navigates to the course player via the parent's
+/// [onTap] callback.
+class CourseCard extends StatelessWidget {
+  const CourseCard({
+    super.key,
+    required this.course,
+    required this.onTap,
+  });
+
+  final Course course;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: AppColors.primary.withOpacity(0.2),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.primary.withOpacity(0.08),
+              blurRadius: 20,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Thumbnail / hero area
+            _CourseThumbnail(course: course),
+
+            // Content area
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Tags
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    children: course.tags
+                        .take(3)
+                        .map((tag) => _TagChip(label: tag))
+                        .toList(),
+                  ),
+                  const SizedBox(height: 10),
+
+                  // Title
+                  Text(
+                    course.title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          height: 1.3,
+                        ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 6),
+
+                  // Author
+                  Row(
+                    children: [
+                      const CircleAvatar(
+                        radius: 10,
+                        backgroundColor: AppColors.primary,
+                        child: Icon(Icons.person, size: 12, color: Colors.white),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        course.author,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(fontSize: 12),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Stats row
+                  Row(
+                    children: [
+                      _StatBadge(
+                        icon: Icons.star_rounded,
+                        iconColor: AppColors.starColor,
+                        label:
+                            '${course.rating} (${_formatCount(course.totalRatings)})',
+                      ),
+                      const SizedBox(width: 12),
+                      _StatBadge(
+                        icon: Icons.timer_outlined,
+                        iconColor: AppColors.primary,
+                        label: '${course.durationMinutes} мин',
+                      ),
+                      const SizedBox(width: 12),
+                      _StatBadge(
+                        icon: Icons.layers_outlined,
+                        iconColor: AppColors.secondary,
+                        label: '${course.moduleCount} уроков',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+
+                  // CTA
+                  SizedBox(
+                    width: double.infinity,
+                    height: 44,
+                    child: ElevatedButton(
+                      onPressed: onTap,
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: Size.zero,
+                      ),
+                      child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.play_circle_outline, size: 18),
+                          SizedBox(width: 8),
+                          Text('Начать курс'),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    )
+        .animate()
+        .fadeIn(duration: 500.ms)
+        .scale(begin: const Offset(0.95, 0.95), end: const Offset(1, 1));
+  }
+
+  String _formatCount(int count) {
+    if (count >= 1000) return '${(count / 1000).toStringAsFixed(1)}k';
+    return count.toString();
+  }
+}
+
+class _CourseThumbnail extends StatelessWidget {
+  const _CourseThumbnail({required this.course});
+
+  final Course course;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 180,
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.primary.withOpacity(0.8),
+            AppColors.secondary.withOpacity(0.6),
+          ],
+        ),
+      ),
+      child: Stack(
+        children: [
+          // Decorative circles
+          Positioned(
+            right: -20,
+            top: -20,
+            child: Container(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.07),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 20,
+            bottom: -30,
+            child: Container(
+              width: 90,
+              height: 90,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.05),
+              ),
+            ),
+          ),
+
+          // Python logo placeholder / icon
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 72,
+                  height: 72,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.15),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: const Center(
+                    child: Text(
+                      '🐍',
+                      style: TextStyle(fontSize: 38),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
+
+          // Duration badge
+          Positioned(
+            top: 12,
+            right: 12,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.black.withOpacity(0.5),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                '${course.durationMinutes} мин',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+
+          // Level badge
+          Positioned(
+            bottom: 12,
+            left: 12,
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: AppColors.success.withOpacity(0.9),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                course.level,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  const _TagChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppColors.primary,
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatBadge extends StatelessWidget {
+  const _StatBadge({
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: iconColor),
+        const SizedBox(width: 3),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontSize: 12,
+                color: AppColors.onSurface,
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'core/router/app_router.dart';
+import 'core/supabase/supabase_config.dart';
+import 'core/theme/app_theme.dart';
+import 'features/auth/bloc/auth_bloc.dart';
+import 'features/auth/repository/auth_repository.dart';
+import 'features/showcase/bloc/showcase_bloc.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await Supabase.initialize(
+    url: SupabaseConfig.supabaseUrl,
+    anonKey: SupabaseConfig.supabaseAnonKey,
+  );
+
+  runApp(const AnimaLearnApp());
+}
+
+class AnimaLearnApp extends StatelessWidget {
+  const AnimaLearnApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (_) => AuthBloc(repository: const AuthRepository()),
+        ),
+        BlocProvider(
+          create: (_) => ShowcaseBloc()..add(const ShowcaseLoadCourses()),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'AnimaLearn',
+        debugShowCheckedModeBanner: false,
+        theme: buildAppTheme(),
+        initialRoute: AppRoutes.registration,
+        onGenerateRoute: AppRouter.onGenerateRoute,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,63 @@
+name: animalearn
+description: AnimaLearn - 2D Content Factory for emotion-script driven learning
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # State Management (BLoC - replacing Riverpod per issue #3)
+  flutter_bloc: ^8.1.6
+  bloc: ^8.1.4
+  equatable: ^2.0.5
+
+  # Backend & API
+  supabase_flutter: ^2.5.0
+  dio: ^5.7.0
+
+  # Animation & Canvas
+  rive: ^0.13.0
+  lottie: ^3.1.0
+  flutter_animate: ^4.5.0
+
+  # UI Components
+  shimmer: ^3.0.0
+  smooth_page_indicator: ^1.2.0
+  flutter_rating_bar: ^4.0.1
+
+  # Data / Serialization
+  freezed_annotation: ^2.4.4
+  json_annotation: ^4.9.0
+
+  # Utilities
+  uuid: ^4.4.0
+  intl: ^0.19.0
+  logger: ^2.4.0
+  shared_preferences: ^2.3.2
+
+  cupertino_icons: ^1.0.8
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+  # Code generation
+  build_runner: ^2.4.12
+  freezed: ^2.5.7
+  json_serializable: ^6.8.0
+
+  # Testing
+  bloc_test: ^9.1.7
+  mocktail: ^1.0.4
+
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/animations/
+    - assets/images/

--- a/supabase/functions/courses/index.ts
+++ b/supabase/functions/courses/index.ts
@@ -1,0 +1,65 @@
+/**
+ * courses — Supabase Edge Function (Deno)
+ *
+ * GET  /courses          → list published courses
+ * GET  /courses/:id      → single course with modules
+ *
+ * Query params:
+ *   ?q=<search>     full-text search
+ *   ?limit=12       page size (default 12)
+ *   ?offset=0       pagination offset
+ */
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+
+  try {
+    const url = new URL(req.url);
+    const q = url.searchParams.get("q");
+    const limit = parseInt(url.searchParams.get("limit") ?? "12", 10);
+    const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
+
+    let query = supabase
+      .from("courses")
+      .select(
+        `id, title, description, author_id, rating, total_ratings,
+         duration_minutes, module_count, level, tags, thumbnail_url,
+         users:author_id ( full_name )`
+      )
+      .eq("published", true)
+      .range(offset, offset + limit - 1)
+      .order("rating", { ascending: false });
+
+    if (q) {
+      query = query.textSearch("fts", q, { type: "websearch" });
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return new Response(JSON.stringify({ courses: data }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("courses error:", err);
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/functions/register/index.ts
+++ b/supabase/functions/register/index.ts
@@ -1,0 +1,82 @@
+/**
+ * register — Supabase Edge Function (Deno)
+ *
+ * Handles fast-registration for the demo:
+ *   POST { email: string, password: string }
+ *   → Creates a Supabase auth user and inserts a row in `users`.
+ *
+ * The Supabase auth.signUp call is done via the Admin client to bypass
+ * email confirmation for the demo flow.
+ */
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req: Request) => {
+  // Handle CORS pre-flight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { email, password } = await req.json();
+
+    if (!email || !password) {
+      return new Response(
+        JSON.stringify({ error: "email and password are required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+
+    // Create auth user (skip email confirmation for demo)
+    const { data: authData, error: authError } =
+      await supabaseAdmin.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+
+    if (authError) {
+      // If user already exists, return 409 so the Flutter client can fall back
+      // to sign-in
+      if (authError.message.includes("already registered")) {
+        return new Response(
+          JSON.stringify({ error: "user_exists", detail: authError.message }),
+          { status: 409, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+      throw authError;
+    }
+
+    const userId = authData.user?.id;
+
+    // Insert a row in the public `users` table (profile)
+    await supabaseAdmin.from("users").insert({
+      id: userId,
+      email,
+      role: "learner",
+      created_at: new Date().toISOString(),
+    });
+
+    return new Response(
+      JSON.stringify({ user_id: userId }),
+      { status: 201, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("register error:", err);
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/reviews/index.ts
+++ b/supabase/functions/reviews/index.ts
@@ -1,0 +1,102 @@
+/**
+ * reviews — Supabase Edge Function (Deno)
+ *
+ * POST { course_id: string, rating: number, text?: string }
+ *   → Inserts a review row and recalculates the course average rating.
+ *
+ * Requires: Authorization: Bearer <user-jwt>
+ */
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+    {
+      auth: { autoRefreshToken: false, persistSession: false },
+      global: { headers: { Authorization: authHeader ?? "" } },
+    }
+  );
+
+  try {
+    // Verify authenticated user
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const { course_id, rating, text } = await req.json();
+
+    if (!course_id || !rating || rating < 1 || rating > 5) {
+      return new Response(
+        JSON.stringify({ error: "course_id and rating (1-5) are required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // Upsert review (one review per user per course)
+    const { error: insertError } = await supabase
+      .from("reviews")
+      .upsert({
+        user_id: user.id,
+        course_id,
+        rating,
+        text: text ?? null,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "user_id,course_id" });
+
+    if (insertError) throw insertError;
+
+    // Recalculate average rating on the courses table
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+
+    const { data: stats } = await supabaseAdmin
+      .from("reviews")
+      .select("rating")
+      .eq("course_id", course_id);
+
+    if (stats && stats.length > 0) {
+      const avg =
+        stats.reduce((sum: number, r: { rating: number }) => sum + r.rating, 0) /
+        stats.length;
+
+      await supabaseAdmin
+        .from("courses")
+        .update({
+          rating: Math.round(avg * 10) / 10,
+          total_ratings: stats.length,
+        })
+        .eq("id", course_id);
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 201,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("reviews error:", err);
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/test/features/auth/auth_bloc_test.dart
+++ b/test/features/auth/auth_bloc_test.dart
@@ -1,0 +1,151 @@
+import 'package:animalearn/features/auth/bloc/auth_bloc.dart';
+import 'package:animalearn/features/auth/repository/auth_repository.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class FakeUser extends Fake implements User {
+  @override
+  String get id => 'test-user-id-123';
+
+  @override
+  String? get email => 'test@example.com';
+}
+
+void main() {
+  late MockAuthRepository mockRepo;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+  });
+
+  group('AuthBloc', () {
+    test('initial state is AuthStatus.initial', () {
+      final bloc = AuthBloc(repository: mockRepo);
+      expect(bloc.state.status, AuthStatus.initial);
+    });
+
+    blocTest<AuthBloc, AuthState>(
+      'emits generatingPassword when AuthPasswordGenerated is added',
+      build: () => AuthBloc(repository: mockRepo),
+      act: (bloc) =>
+          bloc.add(const AuthPasswordGenerated(password: 'TestPass1!')),
+      expect: () => [
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.generatingPassword)
+            .having((s) => s.generatedPassword, 'password', 'TestPass1!'),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'emits failure when login attempted without generated password',
+      build: () => AuthBloc(repository: mockRepo),
+      act: (bloc) =>
+          bloc.add(const AuthLoginRequested(email: 'test@example.com')),
+      expect: () => [
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.failure)
+            .having(
+                (s) => s.errorMessage, 'errorMessage', isNotNull),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'emits loading then success when registration succeeds',
+      build: () {
+        when(() => mockRepo.register(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            )).thenAnswer((_) async => FakeUser());
+        return AuthBloc(repository: mockRepo);
+      },
+      seed: () => const AuthState(
+        status: AuthStatus.generatingPassword,
+        generatedPassword: 'TestPass1!',
+      ),
+      act: (bloc) =>
+          bloc.add(const AuthLoginRequested(email: 'test@example.com')),
+      expect: () => [
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.loading),
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.success)
+            .having((s) => s.userId, 'userId', 'test-user-id-123'),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'falls back to signIn when register throws',
+      build: () {
+        when(() => mockRepo.register(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            )).thenThrow(Exception('already registered'));
+        when(() => mockRepo.signIn(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            )).thenAnswer((_) async => FakeUser());
+        return AuthBloc(repository: mockRepo);
+      },
+      seed: () => const AuthState(
+        status: AuthStatus.generatingPassword,
+        generatedPassword: 'TestPass1!',
+      ),
+      act: (bloc) =>
+          bloc.add(const AuthLoginRequested(email: 'test@example.com')),
+      expect: () => [
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.loading),
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.success),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'emits failure when both register and signIn throw',
+      build: () {
+        when(() => mockRepo.register(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            )).thenThrow(Exception('already registered'));
+        when(() => mockRepo.signIn(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            )).thenThrow(Exception('wrong password'));
+        return AuthBloc(repository: mockRepo);
+      },
+      seed: () => const AuthState(
+        status: AuthStatus.generatingPassword,
+        generatedPassword: 'TestPass1!',
+      ),
+      act: (bloc) =>
+          bloc.add(const AuthLoginRequested(email: 'test@example.com')),
+      expect: () => [
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.loading),
+        isA<AuthState>()
+            .having((s) => s.status, 'status', AuthStatus.failure)
+            .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'resets to initial when AuthReset is added',
+      build: () => AuthBloc(repository: mockRepo),
+      seed: () => const AuthState(
+        status: AuthStatus.success,
+        userId: 'some-id',
+      ),
+      act: (bloc) => bloc.add(const AuthReset()),
+      expect: () => [const AuthState()],
+    );
+
+    test('generatePassword returns non-empty string', () {
+      when(() => mockRepo.generatePassword()).thenReturn('TestPass1!');
+      expect(mockRepo.generatePassword(), isNotEmpty);
+    });
+  });
+}

--- a/test/features/player/emotion_script_parser_test.dart
+++ b/test/features/player/emotion_script_parser_test.dart
@@ -1,0 +1,86 @@
+import 'package:animalearn/features/player/models/emotion_script_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EmotionScriptParser', () {
+    test('parses a single emotion tag', () {
+      const script = '[EMOTION:excited]';
+      final segments = EmotionScriptParser.parse(script);
+      expect(segments, hasLength(1));
+      expect(segments[0], isA<EmotionSegment>());
+      expect((segments[0] as EmotionSegment).emotion, 'excited');
+    });
+
+    test('parses emotion tag followed by narration', () {
+      const script = '[EMOTION:happy] Hello world!';
+      final segments = EmotionScriptParser.parse(script);
+
+      expect(segments, hasLength(2));
+      expect((segments[0] as EmotionSegment).emotion, 'happy');
+      expect((segments[1] as NarrationSegment).text, 'Hello world!');
+    });
+
+    test('parses a code block', () {
+      const script = '[CODE:python]\nprint("hi")\n[/CODE]';
+      final segments = EmotionScriptParser.parse(script);
+
+      expect(segments, hasLength(1));
+      expect(segments[0], isA<CodeSegment>());
+      final code = segments[0] as CodeSegment;
+      expect(code.language, 'python');
+      expect(code.code, 'print("hi")');
+    });
+
+    test('parses interleaved emotions, narrations and code blocks', () {
+      const script = '''
+[EMOTION:excited] Привет!
+[CODE:python]
+x = 42
+[/CODE]
+[EMOTION:happy] Отлично!
+''';
+      final segments = EmotionScriptParser.parse(script);
+
+      // We expect: EmotionSegment, NarrationSegment, CodeSegment, EmotionSegment, NarrationSegment
+      expect(segments.whereType<EmotionSegment>().length, greaterThanOrEqualTo(2));
+      expect(segments.whereType<CodeSegment>().length, 1);
+      final code = segments.whereType<CodeSegment>().first;
+      expect(code.language, 'python');
+      expect(code.code, 'x = 42');
+    });
+
+    test('emotion names are lowercased', () {
+      const script = '[EMOTION:EXCITED]';
+      final segments = EmotionScriptParser.parse(script);
+      expect((segments[0] as EmotionSegment).emotion, 'excited');
+    });
+
+    test('parses plain narration with no tags', () {
+      const script = 'Just plain text here.';
+      final segments = EmotionScriptParser.parse(script);
+      expect(segments, hasLength(1));
+      expect((segments[0] as NarrationSegment).text, 'Just plain text here.');
+    });
+
+    test('returns empty list for empty script', () {
+      final segments = EmotionScriptParser.parse('');
+      expect(segments, isEmpty);
+    });
+
+    test('parses full module 1 script without crashing', () {
+      const script = '''
+[EMOTION:excited] Привет! Я Пайтоша — твой проводник в мир Python.
+[EMOTION:curious] Python — это язык, который читается почти как обычный текст.
+[EMOTION:happy] Давай напишем твою первую программу!
+[CODE:python]
+print("Привет, мир!")
+[/CODE]
+[EMOTION:proud] Отлично! Ты только что написал первую программу на Python!
+''';
+      final segments = EmotionScriptParser.parse(script);
+      expect(segments, isNotEmpty);
+      expect(segments.whereType<EmotionSegment>().length, 4);
+      expect(segments.whereType<CodeSegment>().length, 1);
+    });
+  });
+}

--- a/test/features/player/player_bloc_test.dart
+++ b/test/features/player/player_bloc_test.dart
@@ -1,0 +1,107 @@
+import 'package:animalearn/features/player/bloc/player_bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlayerBloc', () {
+    test('initial state has PlayerStatus.initial', () {
+      expect(PlayerBloc().state.status, PlayerStatus.initial);
+    });
+
+    blocTest<PlayerBloc, PlayerState>(
+      'loads course and enters playing state',
+      build: () => PlayerBloc(),
+      act: (bloc) => bloc.add(const PlayerLoadCourse(courseId: 'python-1h')),
+      wait: const Duration(milliseconds: 600),
+      expect: () => [
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.loading),
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.playing)
+            .having((s) => s.modules, 'modules', isNotEmpty)
+            .having((s) => s.segments, 'segments', isNotEmpty)
+            .having(
+                (s) => s.currentModuleIndex, 'moduleIndex', 0)
+            .having(
+                (s) => s.currentSegmentIndex, 'segmentIndex', 0),
+      ],
+    );
+
+    blocTest<PlayerBloc, PlayerState>(
+      'advances segment on PlayerAdvanceSegment',
+      build: () => PlayerBloc(),
+      act: (bloc) async {
+        bloc.add(const PlayerLoadCourse(courseId: 'python-1h'));
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        bloc.add(const PlayerAdvanceSegment());
+      },
+      wait: const Duration(milliseconds: 700),
+      expect: () => [
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.loading),
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.playing)
+            .having((s) => s.currentSegmentIndex, 'segmentIndex', 0),
+        isA<PlayerState>()
+            .having((s) => s.currentSegmentIndex, 'segmentIndex', 1),
+      ],
+    );
+
+    blocTest<PlayerBloc, PlayerState>(
+      'toggles between playing and paused',
+      build: () => PlayerBloc(),
+      act: (bloc) async {
+        bloc.add(const PlayerLoadCourse(courseId: 'python-1h'));
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        bloc.add(const PlayerTogglePlayback());
+      },
+      wait: const Duration(milliseconds: 700),
+      expect: () => [
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.loading),
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.playing),
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.paused),
+      ],
+    );
+
+    blocTest<PlayerBloc, PlayerState>(
+      'navigates to module 2 with PlayerGoToModule',
+      build: () => PlayerBloc(),
+      act: (bloc) async {
+        bloc.add(const PlayerLoadCourse(courseId: 'python-1h'));
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        bloc.add(const PlayerGoToModule(moduleIndex: 2));
+      },
+      wait: const Duration(milliseconds: 700),
+      expect: () => [
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.loading),
+        isA<PlayerState>()
+            .having((s) => s.currentModuleIndex, 'module', 0),
+        isA<PlayerState>()
+            .having((s) => s.currentModuleIndex, 'module', 2)
+            .having((s) => s.currentSegmentIndex, 'segment', 0),
+      ],
+    );
+
+    blocTest<PlayerBloc, PlayerState>(
+      'ignores invalid module index',
+      build: () => PlayerBloc(),
+      act: (bloc) async {
+        bloc.add(const PlayerLoadCourse(courseId: 'python-1h'));
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        bloc.add(const PlayerGoToModule(moduleIndex: 999));
+      },
+      wait: const Duration(milliseconds: 700),
+      expect: () => [
+        isA<PlayerState>()
+            .having((s) => s.status, 'status', PlayerStatus.loading),
+        isA<PlayerState>()
+            .having((s) => s.currentModuleIndex, 'module', 0),
+        // No additional state change — invalid index is ignored
+      ],
+    );
+  });
+}

--- a/test/features/review/review_bloc_test.dart
+++ b/test/features/review/review_bloc_test.dart
@@ -1,0 +1,63 @@
+import 'package:animalearn/features/review/bloc/review_bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ReviewBloc', () {
+    test('initial state has rating 0 and canSubmit false', () {
+      final bloc = ReviewBloc();
+      expect(bloc.state.rating, 0);
+      expect(bloc.state.canSubmit, false);
+    });
+
+    blocTest<ReviewBloc, ReviewState>(
+      'emits updated rating when ReviewRatingChanged is added',
+      build: () => ReviewBloc(),
+      act: (bloc) => bloc.add(const ReviewRatingChanged(rating: 4.5)),
+      expect: () => [
+        isA<ReviewState>()
+            .having((s) => s.rating, 'rating', 4.5)
+            .having((s) => s.canSubmit, 'canSubmit', true),
+      ],
+    );
+
+    blocTest<ReviewBloc, ReviewState>(
+      'emits updated text when ReviewTextChanged is added',
+      build: () => ReviewBloc(),
+      act: (bloc) =>
+          bloc.add(const ReviewTextChanged(text: 'Great course!')),
+      expect: () => [
+        isA<ReviewState>().having(
+          (s) => s.reviewText,
+          'reviewText',
+          'Great course!',
+        ),
+      ],
+    );
+
+    blocTest<ReviewBloc, ReviewState>(
+      'does not submit when rating is 0',
+      build: () => ReviewBloc(),
+      act: (bloc) =>
+          bloc.add(const ReviewSubmitted(courseId: 'python-1h')),
+      expect: () => [], // No state change
+    );
+
+    // Note: full submission test requires Supabase mock.
+    // We test the canSubmit guard and state transitions here.
+    blocTest<ReviewBloc, ReviewState>(
+      'canSubmit becomes true only after rating is set',
+      build: () => ReviewBloc(),
+      act: (bloc) async {
+        bloc.add(const ReviewRatingChanged(rating: 0)); // invalid
+        bloc.add(const ReviewRatingChanged(rating: 3.0)); // valid
+      },
+      expect: () => [
+        isA<ReviewState>()
+            .having((s) => s.canSubmit, 'canSubmit', false),
+        isA<ReviewState>()
+            .having((s) => s.canSubmit, 'canSubmit', true),
+      ],
+    );
+  });
+}

--- a/test/features/showcase/showcase_bloc_test.dart
+++ b/test/features/showcase/showcase_bloc_test.dart
@@ -1,0 +1,58 @@
+import 'package:animalearn/features/showcase/bloc/showcase_bloc.dart';
+import 'package:animalearn/features/showcase/models/course.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ShowcaseBloc', () {
+    test('initial state is ShowcaseStatus.initial', () {
+      final bloc = ShowcaseBloc();
+      expect(bloc.state.status, ShowcaseStatus.initial);
+      expect(bloc.state.courses, isEmpty);
+    });
+
+    blocTest<ShowcaseBloc, ShowcaseState>(
+      'emits loading then success with demo course after ShowcaseLoadCourses',
+      build: () => ShowcaseBloc(),
+      act: (bloc) => bloc.add(const ShowcaseLoadCourses()),
+      wait: const Duration(seconds: 1),
+      expect: () => [
+        isA<ShowcaseState>()
+            .having((s) => s.status, 'status', ShowcaseStatus.loading),
+        isA<ShowcaseState>()
+            .having((s) => s.status, 'status', ShowcaseStatus.success)
+            .having((s) => s.courses, 'courses', isNotEmpty)
+            .having(
+              (s) => s.courses.first.id,
+              'first course id',
+              'python-1h',
+            ),
+      ],
+    );
+
+    blocTest<ShowcaseBloc, ShowcaseState>(
+      'updates selectedCourseId when ShowcaseCourseSelected is added',
+      build: () => ShowcaseBloc(),
+      act: (bloc) =>
+          bloc.add(const ShowcaseCourseSelected(courseId: 'python-1h')),
+      expect: () => [
+        isA<ShowcaseState>().having(
+          (s) => s.selectedCourseId,
+          'selectedCourseId',
+          'python-1h',
+        ),
+      ],
+    );
+
+    test('demo course has 6 modules', () {
+      expect(Course.demoModules, hasLength(6));
+    });
+
+    test('demo course modules all have non-empty emotion scripts', () {
+      for (final module in Course.demoModules) {
+        expect(module.emotionScript, isNotEmpty,
+            reason: 'Module "${module.title}" has empty emotionScript');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the full demo user journey from issue #3.

### What's in this PR

**4-screen demo flow:**
1. **RegistrationScreen** — single email field, auto-generated password shown in a read-only field with copy button, "Войти и начать" button
2. **ShowcaseScreen** — course catalog with a "Выучи Python за 1 час" card (rating, tags, stats, CTA)
3. **PlayerScreen** — step-through course player: `EmotionAvatar` animates per `[EMOTION:xxx]` tags, narration shown as text cards, code shown in syntax-highlighted blocks, module list sidebar
4. **ReviewScreen** — star rating (1–5 via `flutter_rating_bar`) + optional text, submitted to Supabase Edge Function `reviews`

**Architecture changes (required by issue #3):**

| Before | After |
|--------|-------|
| GoRouter | Flutter built-in `Navigator` + `MaterialPageRoute` (MaterialRouter) |
| Riverpod | `flutter_bloc` (BLoC pattern) |

**Backend — Supabase + Deno Edge Functions:**
- `supabase/functions/register/` — fast-registration, skips email confirmation for demo
- `supabase/functions/courses/` — list/search published courses
- `supabase/functions/reviews/` — upsert review, recalculate average rating

**EmotionScript parser** (`EmotionScriptParser`) — parses `[EMOTION:name]`, `[CODE:lang]...[/CODE]`, and plain narration text into a typed `List<ScriptSegment>`.

### Tests

Unit tests with `bloc_test` + `mocktail` covering:
- `EmotionScriptParser` (8 cases)
- `AuthBloc` (6 cases including register/sign-in fallback)
- `ShowcaseBloc` (5 cases)
- `PlayerBloc` (5 cases)
- `ReviewBloc` (5 cases)

### Docs updated
- `idea/architecture/system-architecture.md` — full BLoC + MaterialRouter architecture
- `idea/screens/00-navigation.md` — MaterialRouter route map
- `idea/flutter-libraries.md` — updated pubspec.yaml (BLoC replaces Riverpod, no GoRouter)

## Test plan

- [ ] `flutter pub get` to install dependencies
- [ ] `flutter test` — all BLoC and parser unit tests pass
- [ ] `flutter run` on iOS/Android/Web — verify 4-screen flow end-to-end
- [ ] Configure `SUPABASE_URL` + `SUPABASE_ANON_KEY` in `SupabaseConfig` for live backend
- [ ] Deploy Deno Edge Functions: `supabase functions deploy register courses reviews`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #3